### PR TITLE
fix: tolerate GPU VM migration in hookscript check

### DIFF
--- a/roles/pve/hookscripts/tasks/main.yml
+++ b/roles/pve/hookscripts/tasks/main.yml
@@ -21,6 +21,7 @@
   loop: "{{ pve_gpu_vms | dict2items }}"
   register: vm_configs
   changed_when: false
+  failed_when: false
   when: inventory_hostname == 'pve2'
 
 - name: Attach hookscript to GPU VMs
@@ -29,6 +30,7 @@
   loop: "{{ vm_configs.results }}"
   when:
     - inventory_hostname == 'pve2'
+    - item.rc is defined and item.rc == 0
     - item.stdout is defined
     - "'hookscript: local:snippets/gpu-failover.sh' not in item.stdout"
   changed_when: true

--- a/roles/pve/hookscripts/tasks/main.yml
+++ b/roles/pve/hookscripts/tasks/main.yml
@@ -21,7 +21,7 @@
   loop: "{{ pve_gpu_vms | dict2items }}"
   register: vm_configs
   changed_when: false
-  failed_when: false
+  failed_when: rc != 0 and 'does not exist' not in stderr
   when: inventory_hostname == 'pve2'
 
 - name: Attach hookscript to GPU VMs


### PR DESCRIPTION
## Summary
- `qm config 115` fails on pve2 when VM 115 has been HA-migrated to pve — the conf file doesn't exist on the non-owning node
- Added `failed_when: false` to the hookscript check task so it gracefully handles missing VMs
- Added `item.rc == 0` guard on the attach task to skip VMs not on the current node

## Test plan
- [ ] Merge and wait for next ansible-proxmox timer run (~1hr)
- [ ] Verify Grafana Quasar Overview shows ansible timer OK (green)
- [ ] Confirm `systemctl status ansible-proxmox.service` exits 0