### PR TITLE
fix(pve): wait for TrueNAS API before pve-guests autostarts VMs

### DIFF
--- a/roles/pve/freenas_iscsi/defaults/main.yml
+++ b/roles/pve/freenas_iscsi/defaults/main.yml
@@ -18,3 +18,11 @@ freenas_patched_files:
 # FreeNAS.pm module (copied, not patched)
 freenas_module_src: "/usr/local/src/freenas-proxmox/perl5/PVE/Storage/LunCmd/FreeNAS.pm"
 freenas_module_dest: "/usr/share/perl5/PVE/Storage/LunCmd/FreeNAS.pm"
+
+# pve-guests wait-for-TrueNAS-API drop-in
+# Blocks pve-guests.service until the TrueNAS REST API is reachable,
+# so onboot VMs with ZFS-over-iSCSI disks do not fail to start during
+# a cold boot race. See 2026-04-13 incident.
+freenas_api_wait_url: "https://10.10.12.2/api/v2.0/system/info"
+freenas_api_wait_timeout_secs: 120
+freenas_api_wait_interval_secs: 2

--- a/roles/pve/freenas_iscsi/files/wait-truenas-api.sh
+++ b/roles/pve/freenas_iscsi/files/wait-truenas-api.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Wait for the TrueNAS API to respond before pve-guests starts its VMs.
+#
+# The freenas-proxmox plugin calls the TrueNAS REST API at VM start time
+# to resolve iSCSI extent paths. If pve-guests fires before the API is
+# reachable (common on a cold boot where TrueNAS is still booting up or
+# the storage network link is still negotiating), the plugin fails fast
+# and onboot VMs stay stopped. See 2026-04-13 incident.
+#
+# Env vars (set via systemd drop-in, managed by Ansible role):
+#   TRUENAS_API_URL       full URL to poll, default https://10.10.12.2/api/v2.0/system/info
+#   TRUENAS_API_TIMEOUT   seconds to wait total, default 120
+#   TRUENAS_API_INTERVAL  seconds between attempts, default 2
+#
+# Exits 0 on success OR on timeout. We never block pve-guests forever
+# (the plugin's own error is more actionable than a hung boot).
+
+set -u
+
+API_URL="${TRUENAS_API_URL:-https://10.10.12.2/api/v2.0/system/info}"
+TIMEOUT_SECS="${TRUENAS_API_TIMEOUT:-120}"
+INTERVAL="${TRUENAS_API_INTERVAL:-2}"
+
+deadline=$(( $(date +%s) + TIMEOUT_SECS ))
+attempts=0
+
+while [ "$(date +%s)" -lt "$deadline" ]; do
+    attempts=$((attempts + 1))
+    if curl -ksfL --max-time 3 -o /dev/null "$API_URL"; then
+        logger -t wait-truenas-api "TrueNAS API at $API_URL reachable after $attempts attempt(s)"
+        exit 0
+    fi
+    sleep "$INTERVAL"
+done
+
+logger -t wait-truenas-api "TIMEOUT after ${TIMEOUT_SECS}s and $attempts attempt(s) waiting for $API_URL; letting pve-guests proceed"
+exit 0

--- a/roles/pve/freenas_iscsi/tasks/main.yml
+++ b/roles/pve/freenas_iscsi/tasks/main.yml
@@ -107,3 +107,33 @@
     group: root
     mode: '0644'
   notify: Restart PVE services
+
+- name: Install wait-truenas-api helper script
+  ansible.builtin.copy:
+    src: wait-truenas-api.sh
+    dest: /usr/local/sbin/wait-truenas-api.sh
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Ensure pve-guests drop-in directory exists
+  ansible.builtin.file:
+    path: /etc/systemd/system/pve-guests.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Deploy pve-guests wait-for-TrueNAS-API drop-in
+  ansible.builtin.template:
+    src: pve-guests-wait-truenas.conf.j2
+    dest: /etc/systemd/system/pve-guests.service.d/wait-truenas-api.conf
+    owner: root
+    group: root
+    mode: '0644'
+  register: pve_guests_dropin
+
+- name: Reload systemd so the new drop-in is picked up
+  ansible.builtin.systemd:
+    daemon_reload: true
+  when: pve_guests_dropin.changed

--- a/roles/pve/freenas_iscsi/templates/pve-guests-wait-truenas.conf.j2
+++ b/roles/pve/freenas_iscsi/templates/pve-guests-wait-truenas.conf.j2
@@ -1,0 +1,9 @@
+# {{ ansible_managed }}
+# Drop-in for pve-guests.service that blocks VM autostart until the
+# TrueNAS API is reachable. Closes the freenas-proxmox boot race
+# (see 2026-04-13 incident).
+[Service]
+Environment=TRUENAS_API_URL={{ freenas_api_wait_url }}
+Environment=TRUENAS_API_TIMEOUT={{ freenas_api_wait_timeout_secs }}
+Environment=TRUENAS_API_INTERVAL={{ freenas_api_wait_interval_secs }}
+ExecStartPre=/usr/local/sbin/wait-truenas-api.sh


### PR DESCRIPTION
## Summary

Closes the freenas-proxmox boot race that caused the 2026-04-13 incident (4 VMs stayed down for ~9 hours after a clean reboot of pve).

On cold boot, `pve-guests.service` fires ~13 seconds after the kernel hands off. The freenas-proxmox plugin (which backs the ZFS-over-iSCSI storage) calls the TrueNAS REST API at `https://10.10.12.2/api/v2.0/system/info` while starting each VM. If the API is not yet reachable (TrueNAS still booting, storage network still negotiating, multipath still settling), the plugin fails fast with:

```
Unable to connect to the FreeNAS API service at '10.10.12.2' using the 'https' protocol
```

The plugin does not retry. VMs 100 (npm), 104 (timescaleDB), 110 (k8cluster1), 111 (k8cluster3), 112 (nginx1), 113 (nginx2), 117 (uptime-kuma) all failed in a 25-second window. VM 119 (postgresql) caught the API being up and started successfully, which is why the failure looked so inconsistent from outside.

## Changes

- New script `roles/pve/freenas_iscsi/files/wait-truenas-api.sh` that polls the configured TrueNAS endpoint up to a configurable timeout (default 120s, 2s interval).
- New systemd drop-in `roles/pve/freenas_iscsi/templates/pve-guests-wait-truenas.conf.j2` wiring `ExecStartPre=/usr/local/sbin/wait-truenas-api.sh` into `pve-guests.service`.
- Ansible tasks to deploy the script, the drop-in dir, and the drop-in itself, plus a conditional `daemon-reload` when the drop-in changes.
- Three new defaults (`freenas_api_wait_url`, `freenas_api_wait_timeout_secs`, `freenas_api_wait_interval_secs`) so per-host `host_vars` can override if needed (e.g. pve uses a different storage IP than pve2 in the future).

## Design notes

- Script exits 0 even on timeout. Blocking pve-guests forever on a truly dead TrueNAS would be worse than letting the plugin raise its own error, which is more actionable and logged per-VM.
- Poll uses `curl -ksfL --max-time 3`. Insecure TLS is intentional (TrueNAS internal cert on the storage VLAN, same as the freenas-proxmox plugin itself does).
- Runs on every pve node because both hosts share the same freenas_iscsi role; behavior on pve2 is harmless since pve2's onboot VMs also depend on TrueNAS storage.

## Test plan

- [ ] `ansible-playbook playbooks/proxmox.yml --check --diff` shows the drop-in + script being created on both pve and pve2.
- [ ] Apply to both nodes: `ansible-playbook playbooks/proxmox.yml --tags freenas_iscsi` (or full playbook).
- [ ] Confirm files exist:
      `ls /etc/systemd/system/pve-guests.service.d/wait-truenas-api.conf /usr/local/sbin/wait-truenas-api.sh`
- [ ] `systemctl cat pve-guests.service` shows the drop-in merged.
- [ ] Reboot pve during a low-traffic window and verify `journalctl -b 0 -t wait-truenas-api` logs a success message, and that all onboot=1 VMs (100, 104, 110, 111, 112, 113, 115, 117, 119) come up without manual intervention.
- [ ] Negative test (optional): temporarily point `freenas_api_wait_url` at an unreachable host via `host_vars`, re-apply, reboot, verify the 120s timeout fires, the script logs a TIMEOUT line, and pve-guests still runs afterward (failing the way it did on 2026-04-13, which is expected fallback).