### PR TITLE
fix(pve): accept any HTTP response from TrueNAS API probe

### DIFF
--- a/roles/pve/freenas_iscsi/files/wait-truenas-api.sh
+++ b/roles/pve/freenas_iscsi/files/wait-truenas-api.sh
@@ -26,8 +26,13 @@ attempts=0
 
 while [ "$(date +%s)" -lt "$deadline" ]; do
     attempts=$((attempts + 1))
-    if curl -ksfL --max-time 3 -o /dev/null "$API_URL"; then
-        logger -t wait-truenas-api "TrueNAS API at $API_URL reachable after $attempts attempt(s)"
+    # Any 3-digit HTTP response means the API daemon is serving (even 401
+    # without auth, which is what an unauthenticated GET returns). We only
+    # care that the daemon is up, not that our probe is authorized, so do
+    # NOT pass -f.
+    http_code=$(curl -ks --max-time 3 -o /dev/null -w '%{http_code}' "$API_URL" 2>/dev/null || true)
+    if [[ "$http_code" =~ ^[1-5][0-9]{2}$ ]]; then
+        logger -t wait-truenas-api "TrueNAS API at $API_URL reachable (HTTP $http_code) after $attempts attempt(s)"
         exit 0
     fi
     sleep "$INTERVAL"


### PR DESCRIPTION
## Summary

Follow-up to #98. The script that landed still uses \`curl -ksfL\`. The \`-f\` flag makes curl exit non-zero on any HTTP 4xx/5xx, and an unauthenticated GET against \`/api/v2.0/system/info\` returns \`401 Unauthorized\` (correct TrueNAS behavior). So the probe decides the API is down even when it is responding in under 10ms.

Observed during end-to-end testing of #98:
- Manual run on both pve and pve2: 59 attempts, 120s timeout, then exit.
- \`curl -ksfL --max-time 5 -o /dev/null https://10.10.12.2/api/v2.0/system/info\` returns HTTP 401 in ~10ms.
- \`journalctl -t wait-truenas-api\` on pve after an ad-hoc test: \`TIMEOUT after 120s and 59 attempt(s)\`.

Net effect of the bug as-is: every cold boot adds 120s of dead wait before pve-guests runs, then falls through and the plugin tries anyway. VMs still come up (eventually), but the guard is not actually gating on the real condition, so if the API genuinely is not up, the guard also does nothing useful.

## Change

Drop \`-f\`. Read \`%{http_code}\` and accept any 3-digit response as \"API daemon is serving\". We do not care whether the probe itself is authorized, only that the daemon is up and responding.

## Test plan

- [ ] After merge and apply, \`time /usr/local/sbin/wait-truenas-api.sh\` returns in well under 1s when the TrueNAS API is reachable.
- [ ] \`journalctl -t wait-truenas-api\` logs \`reachable (HTTP 401) after 1 attempt(s)\`.
- [ ] Reboot pve during a low-traffic window and confirm the ExecStartPre does not add a 120s delay to boot, and all onboot VMs start normally.