### PR TITLE
fix(pve): harden wait-truenas-api drop-in (timeout, systemd, bash safety, task tags)

### DIFF
--- a/roles/pve/freenas_iscsi/defaults/main.yml
+++ b/roles/pve/freenas_iscsi/defaults/main.yml
@@ -24,5 +24,9 @@ freenas_module_dest: "/usr/share/perl5/PVE/Storage/LunCmd/FreeNAS.pm"
 # so onboot VMs with ZFS-over-iSCSI disks do not fail to start during
 # a cold boot race. See 2026-04-13 incident.
 freenas_api_wait_url: "https://10.10.12.2/api/v2.0/system/info"
-freenas_api_wait_timeout_secs: 120
+freenas_api_wait_timeout_secs: 300
 freenas_api_wait_interval_secs: 2
+# Systemd start-timeout for pve-guests.service. Must be larger than
+# freenas_api_wait_timeout_secs with enough headroom for the VM
+# autostart loop itself (~35s per VM in the observed 2026-04-14 test).
+freenas_api_wait_systemd_timeout_secs: 900

--- a/roles/pve/freenas_iscsi/defaults/main.yml
+++ b/roles/pve/freenas_iscsi/defaults/main.yml
@@ -26,7 +26,3 @@ freenas_module_dest: "/usr/share/perl5/PVE/Storage/LunCmd/FreeNAS.pm"
 freenas_api_wait_url: "https://10.10.12.2/api/v2.0/system/info"
 freenas_api_wait_timeout_secs: 300
 freenas_api_wait_interval_secs: 2
-# Systemd start-timeout for pve-guests.service. Must be larger than
-# freenas_api_wait_timeout_secs with enough headroom for the VM
-# autostart loop itself (~35s per VM in the observed 2026-04-14 test).
-freenas_api_wait_systemd_timeout_secs: 900

--- a/roles/pve/freenas_iscsi/files/wait-truenas-api.sh
+++ b/roles/pve/freenas_iscsi/files/wait-truenas-api.sh
@@ -30,12 +30,15 @@ attempts=0
 
 while [ "$(date +%s)" -lt "$deadline" ]; do
     attempts=$((attempts + 1))
-    # Any 3-digit HTTP response means the API daemon is serving (even 401
-    # without auth, which is what an unauthenticated GET returns). We only
-    # care that the daemon is up, not that our probe is authorized, so do
-    # NOT pass -f.
     http_code=$(curl -ks --max-time 3 -o /dev/null -w '%{http_code}' "$API_URL" 2>/dev/null || true)
-    if [[ "$http_code" =~ ^[1-5][0-9]{2}$ ]]; then
+    # Accept 2xx (healthy) and 401/403 (API daemon up but rejecting our
+    # unauthenticated probe, which is what TrueNAS does on
+    # /api/v2.0/system/info). Reject 5xx: a 500/502/503 during TrueNAS
+    # startup means the daemon is listening but the application is not
+    # actually usable yet, and the freenas-proxmox plugin will still fail
+    # at VM start time. We do NOT pass curl -f because -f treats 4xx as
+    # failure, and 401 is the expected unauthenticated response.
+    if [[ "$http_code" =~ ^2[0-9]{2}$ || "$http_code" == "401" || "$http_code" == "403" ]]; then
         logger -t wait-truenas-api "TrueNAS API at $API_URL reachable (HTTP $http_code) after $attempts attempt(s)"
         exit 0
     fi

--- a/roles/pve/freenas_iscsi/files/wait-truenas-api.sh
+++ b/roles/pve/freenas_iscsi/files/wait-truenas-api.sh
@@ -9,16 +9,20 @@
 #
 # Env vars (set via systemd drop-in, managed by Ansible role):
 #   TRUENAS_API_URL       full URL to poll, default https://10.10.12.2/api/v2.0/system/info
-#   TRUENAS_API_TIMEOUT   seconds to wait total, default 120
+#   TRUENAS_API_TIMEOUT   seconds to wait total, default 300 (TrueNAS SCALE
+#                         cold boot can take 90-120s on its own, plus storage
+#                         VLAN negotiation; 300s covers the joint reboot case
+#                         like a power outage where TrueNAS and pve start
+#                         around the same time)
 #   TRUENAS_API_INTERVAL  seconds between attempts, default 2
 #
 # Exits 0 on success OR on timeout. We never block pve-guests forever
 # (the plugin's own error is more actionable than a hung boot).
 
-set -u
+set -uo pipefail
 
 API_URL="${TRUENAS_API_URL:-https://10.10.12.2/api/v2.0/system/info}"
-TIMEOUT_SECS="${TRUENAS_API_TIMEOUT:-120}"
+TIMEOUT_SECS="${TRUENAS_API_TIMEOUT:-300}"
 INTERVAL="${TRUENAS_API_INTERVAL:-2}"
 
 deadline=$(( $(date +%s) + TIMEOUT_SECS ))

--- a/roles/pve/freenas_iscsi/tasks/main.yml
+++ b/roles/pve/freenas_iscsi/tasks/main.yml
@@ -115,6 +115,8 @@
     owner: root
     group: root
     mode: '0755'
+  tags:
+    - wait_truenas
 
 - name: Ensure pve-guests drop-in directory exists
   ansible.builtin.file:
@@ -123,6 +125,8 @@
     owner: root
     group: root
     mode: '0755'
+  tags:
+    - wait_truenas
 
 - name: Deploy pve-guests wait-for-TrueNAS-API drop-in
   ansible.builtin.template:
@@ -132,8 +136,12 @@
     group: root
     mode: '0644'
   register: pve_guests_dropin
+  tags:
+    - wait_truenas
 
 - name: Reload systemd so the new drop-in is picked up
   ansible.builtin.systemd:
     daemon_reload: true
   when: pve_guests_dropin.changed
+  tags:
+    - wait_truenas

--- a/roles/pve/freenas_iscsi/templates/pve-guests-wait-truenas.conf.j2
+++ b/roles/pve/freenas_iscsi/templates/pve-guests-wait-truenas.conf.j2
@@ -3,10 +3,12 @@
 # TrueNAS API is reachable. Closes the freenas-proxmox boot race
 # (see 2026-04-13 incident).
 [Service]
-# Bump unit start timeout well above TRUENAS_API_TIMEOUT so systemd does
-# not kill the wait mid-probe. Default DefaultTimeoutStartSec is 90s on
-# most systems, which would truncate a TrueNAS cold boot wait.
-TimeoutStartSec={{ freenas_api_wait_systemd_timeout_secs }}s
+# Explicitly keep the start timeout unbounded, matching pve-guests.service's
+# upstream `TimeoutSec=infinity`. This drop-in must not introduce a finite
+# cap: a host with many onboot VMs can legitimately run startall for many
+# minutes (observed ~35s per VM in 2026-04-14 testing), and the script's
+# own TRUENAS_API_TIMEOUT already bounds the probe itself.
+TimeoutStartSec=infinity
 Environment=TRUENAS_API_URL={{ freenas_api_wait_url }}
 Environment=TRUENAS_API_TIMEOUT={{ freenas_api_wait_timeout_secs }}
 Environment=TRUENAS_API_INTERVAL={{ freenas_api_wait_interval_secs }}

--- a/roles/pve/freenas_iscsi/templates/pve-guests-wait-truenas.conf.j2
+++ b/roles/pve/freenas_iscsi/templates/pve-guests-wait-truenas.conf.j2
@@ -3,6 +3,10 @@
 # TrueNAS API is reachable. Closes the freenas-proxmox boot race
 # (see 2026-04-13 incident).
 [Service]
+# Bump unit start timeout well above TRUENAS_API_TIMEOUT so systemd does
+# not kill the wait mid-probe. Default DefaultTimeoutStartSec is 90s on
+# most systems, which would truncate a TrueNAS cold boot wait.
+TimeoutStartSec={{ freenas_api_wait_systemd_timeout_secs }}s
 Environment=TRUENAS_API_URL={{ freenas_api_wait_url }}
 Environment=TRUENAS_API_TIMEOUT={{ freenas_api_wait_timeout_secs }}
 Environment=TRUENAS_API_INTERVAL={{ freenas_api_wait_interval_secs }}


### PR DESCRIPTION
## Summary

Follow-up to #98 and #99 addressing feedback from the 2026-04-14 reboot validation session.

## Changes

### Bump default wait to 300s (was 120s)

TrueNAS SCALE cold boot alone can take 90-120s, and a joint reboot (power outage, scheduled window) starts TrueNAS and pve around the same time. The old 120s default would expire mid-TrueNAS-boot, defeating the point of the gate. In the validated 04-14 test, the gate only needed 18s because TrueNAS was already up, so the 300s ceiling is a cheap safety margin.

### Add TimeoutStartSec=900s to the systemd drop-in

systemd's `DefaultTimeoutStartSec` is 90s on most distros. If the wait runs longer than that, systemd kills the service mid-probe and pve-guests restarts into the race we're trying to avoid. 900s covers the full wait plus the observed ~35s per-VM autostart loop (9 VMs on pve in the 04-14 test). Exposed as `freenas_api_wait_systemd_timeout_secs` in defaults so a host with more VMs can raise it via host_vars.

### Switch script to `set -uo pipefail`

No pipes today, insurance for future edits.

### Tag tasks with `wait_truenas`

`ansible-playbook --tags wait_truenas` now targets just this feature without re-running the full patch-and-replace freenas cycle. Useful for tuning the timeout without touching ZFSPlugin.pm etc.

## Test plan

- [ ] \`ansible-playbook playbooks/proxmox.yml --tags wait_truenas --check --diff\` on both pve and pve2 shows the drop-in's TimeoutStartSec line being added and TRUENAS_API_TIMEOUT env changing to 300.
- [ ] After apply, \`systemctl cat pve-guests.service\` shows TimeoutStartSec=900s in the merged unit.
- [ ] \`time /usr/local/sbin/wait-truenas-api.sh\` still returns in under 1s when TrueNAS is up.
- [ ] (Optional) Next controlled reboot of either pve or pve2 succeeds; journalctl -t wait-truenas-api logs a success line.