### PR TITLE
chore(pve): disable fancontrol on both nodes

### DIFF
--- a/roles/pve/common/tasks/main.yml
+++ b/roles/pve/common/tasks/main.yml
@@ -86,10 +86,21 @@
 # NodeFailedUnits signal. BIOS-level fan curves handle cooling fine
 # on both hosts (observed Tctl ~57C, Tccd2 ~70C under normal load),
 # so disable the unit entirely.
+#
+# We check for the unit before touching it so a future host that does
+# not have fancontrol installed does not fail the play, while still
+# surfacing any real systemd/DBus errors on hosts that do.
+- name: Check whether fancontrol unit exists
+  ansible.builtin.command: systemctl list-unit-files fancontrol.service
+  register: fancontrol_unit
+  changed_when: false
+  failed_when: false
+  check_mode: false
+
 - name: Disable fancontrol (empty config, BIOS handles fan curves)
   ansible.builtin.systemd:
     name: fancontrol
     enabled: false
     state: stopped
     masked: true
-  failed_when: false
+  when: "'fancontrol.service' in fancontrol_unit.stdout"

--- a/roles/pve/common/tasks/main.yml
+++ b/roles/pve/common/tasks/main.yml
@@ -78,3 +78,18 @@
     enabled: true
     state: started
   loop: "{{ pve_iscsi_services }}"
+
+# fancontrol ships installed-but-unconfigured (/etc/fancontrol has all
+# mandatory fields blank unless someone runs pwmconfig interactively).
+# The unit fails at boot on both pve and pve2, which shows up as a
+# permanent failed-unit in systemctl --failed and pollutes the
+# NodeFailedUnits signal. BIOS-level fan curves handle cooling fine
+# on both hosts (observed Tctl ~57C, Tccd2 ~70C under normal load),
+# so disable the unit entirely.
+- name: Disable fancontrol (empty config, BIOS handles fan curves)
+  ansible.builtin.systemd:
+    name: fancontrol
+    enabled: false
+    state: stopped
+    masked: true
+  failed_when: false


### PR DESCRIPTION
## Summary

Both pve and pve2 have \`fancontrol.service\` in a permanent \`failed\` state because \`/etc/fancontrol\` ships blank (pwmconfig was never completed). BIOS-level fan curves handle cooling just fine on both hosts.

Observed on pve2 during the 2026-04-14 reboot validation:
\`\`\`
UNIT               LOAD   ACTIVE SUB    DESCRIPTION
fancontrol.service loaded failed failed fan speed regulator

Apr 14 09:20:08 pve2 fancontrol[1197]: Some mandatory settings missing, please check your config file!
\`\`\`

## Change

Add an idempotent task in \`roles/pve/common\` that stops, disables, and masks the unit. \`masked: true\` stops it from coming back on package upgrade. \`failed_when: false\` keeps this a no-op on hypothetical hosts where the package is not even installed.

Temperatures under normal load are well within spec (Tctl 57C, Tccd2 70C), so we are not losing thermal management; BIOS handles it.

## Test plan

- [ ] \`ansible-playbook playbooks/proxmox.yml --check --diff --limit proxmox\` shows the unit being stopped/disabled/masked on both pve and pve2.
- [ ] Apply: \`systemctl --failed\` on both hosts is empty afterward.
- [ ] \`systemctl is-enabled fancontrol\` returns \`masked\`.