### PR TITLE
fix(pve): null-safe failed_when on hookscript GPU VM check

### DIFF
--- a/roles/pve/hookscripts/tasks/main.yml
+++ b/roles/pve/hookscripts/tasks/main.yml
@@ -21,7 +21,15 @@
   loop: "{{ pve_gpu_vms | dict2items }}"
   register: vm_configs
   changed_when: false
-  failed_when: rc != 0 and 'does not exist' not in stderr
+  # Suppress only the "VM lives on a different node" case so migration
+  # is tolerated; real errors (permissions, broken binaries, etc.) still
+  # fail the play. default() wrappers are required because a stricter
+  # `rc != 0 and ...` form intermittently surfaced 'rc is undefined'
+  # errors inside the loop context (see 2026-04-14 ansible run where
+  # proxmox.yml failed on pve2 for item.key=115).
+  failed_when: >-
+    (rc | default(0)) != 0
+    and 'does not exist' not in (stderr | default(''))
   when: inventory_hostname == 'pve2'
 
 - name: Attach hookscript to GPU VMs


### PR DESCRIPTION
## Summary

Follow-up to #96. The narrow \`failed_when\` expression introduced there (5a1fdbd)

\`\`\`yaml
failed_when: rc != 0 and 'does not exist' not in stderr
\`\`\`

crashes on this Ansible version with:

\`\`\`
The conditional check 'rc != 0 and 'does not exist' not in stderr' failed.
The error was: error while evaluating conditional: 'rc' is undefined.
\`\`\`

Happens in the \`loop\` context when looking up a VM that does not live on the current node (jellyfin's VM 115 checked on pve2 while it is actually running on pve). That failure has been flipping \`proxmox.yml\` red in the scheduled \`run-proxmox.sh\` cadence, showing up as \`AnsiblePlaybookFailed\` alerts every run.

## Fix

Wrap \`rc\` and \`stderr\` with \`default()\` so an undefined value becomes \`0\` / \`''\` respectively. Intent is unchanged:
- migration-induced "does not exist" stays suppressed
- every other non-zero exit still fails the play

## Test plan

- [ ] \`ansible-playbook --syntax-check playbooks/proxmox.yml\` passes (did).
- [ ] After merge, scheduled \`run-proxmox.sh\` next cycle completes without \`failed=1\` on pve2 for the hookscript check.
- [ ] \`AnsiblePlaybookFailed{playbook="proxmox.yml"}\` clears from the AlertManager firing list.
- [ ] (Negative) With a deliberately broken \`qm\` binary (e.g. \`chmod 000\`), the task DOES fail, confirming real errors still surface.