### PR TITLE
feat(scripts): 1Password rate-limit kill switch

### DIFF
--- a/scripts/lib/op-killswitch.sh
+++ b/scripts/lib/op-killswitch.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# 1Password rate-limit kill switch.
+#
+# When the service account rate limit is hit, the rolling-hour window can
+# stay pinned for many hours if automation keeps retrying. This library
+# provides a shared lock-file based kill switch so the first script that
+# detects "Too many requests" sets a lock, and every subsequent script
+# run (wrappers, vault-pass, inventory resolve) exits early instead of
+# making another `op` call that extends the window.
+#
+# Usage (sourced from another script):
+#     source "${REPO_DIR}/scripts/lib/op-killswitch.sh"
+#     op_killswitch_check_or_exit   # exits 0 early if lock active
+#     ...
+#     # after running `op` or an ansible-playbook that uses `op`:
+#     op_killswitch_scan_file "$tmpfile"   # sets lock if rate-limit in output
+#
+# The lock file stores the Unix timestamp it was created. Treat a lock
+# as active while mtime is within OP_KILLSWITCH_TTL_SECS of now (default
+# 86400 = 24h). Remove manually with `rm "$OP_KILLSWITCH_LOCK"` once the
+# 1P window has cleared, or wait for the TTL to expire.
+#
+# Prometheus metrics (via node_exporter textfile collector) are written
+# on every check so dashboards and alerts can show the state.
+
+OP_KILLSWITCH_STATE_DIR="${OP_KILLSWITCH_STATE_DIR:-/var/lib/ansible-quasarlab}"
+OP_KILLSWITCH_LOCK="${OP_KILLSWITCH_LOCK:-${OP_KILLSWITCH_STATE_DIR}/1p-killswitch}"
+OP_KILLSWITCH_TTL_SECS="${OP_KILLSWITCH_TTL_SECS:-86400}"
+OP_KILLSWITCH_METRIC_FILE="${OP_KILLSWITCH_METRIC_FILE:-/var/lib/node_exporter/textfiles/onepassword_killswitch.prom}"
+
+# Ensure the state dir exists with sane perms. Best-effort; failures do
+# not abort the caller because permission issues should be surfaced
+# explicitly, not swallowed by killswitch plumbing.
+op_killswitch_init() {
+    mkdir -p "$OP_KILLSWITCH_STATE_DIR" 2>/dev/null || true
+}
+
+# Returns 0 if the killswitch is currently active, 1 otherwise.
+# Side effect: writes the Prometheus metric file.
+op_killswitch_is_active() {
+    op_killswitch_init
+    local active=0
+    local tripped_at=0
+    local age=0
+
+    if [[ -f "$OP_KILLSWITCH_LOCK" ]]; then
+        tripped_at=$(stat -c %Y "$OP_KILLSWITCH_LOCK" 2>/dev/null || echo 0)
+        age=$(( $(date +%s) - tripped_at ))
+        if (( age < OP_KILLSWITCH_TTL_SECS )); then
+            active=1
+        fi
+    fi
+
+    op_killswitch_write_metric "$active" "$tripped_at"
+    [[ $active -eq 1 ]]
+}
+
+# Writes the Prometheus textfile. Called by is_active and trip.
+op_killswitch_write_metric() {
+    local active="${1:-0}"
+    local tripped_at="${2:-0}"
+    local metric_dir
+    metric_dir=$(dirname "$OP_KILLSWITCH_METRIC_FILE")
+    # Best-effort: if the textfile dir is not writable, skip the metric.
+    [[ -d "$metric_dir" && -w "$metric_dir" ]] || return 0
+
+    cat > "${OP_KILLSWITCH_METRIC_FILE}.tmp" <<METRICS
+# HELP onepassword_killswitch_active 1 if the 1Password rate-limit killswitch is currently tripped, 0 otherwise.
+# TYPE onepassword_killswitch_active gauge
+onepassword_killswitch_active ${active}
+# HELP onepassword_killswitch_tripped_timestamp_seconds Unix timestamp when the current killswitch was tripped (0 if inactive).
+# TYPE onepassword_killswitch_tripped_timestamp_seconds gauge
+onepassword_killswitch_tripped_timestamp_seconds ${tripped_at}
+# HELP onepassword_killswitch_ttl_seconds Configured kill-switch TTL in seconds; lock is auto-cleared after this.
+# TYPE onepassword_killswitch_ttl_seconds gauge
+onepassword_killswitch_ttl_seconds ${OP_KILLSWITCH_TTL_SECS}
+METRICS
+    mv "${OP_KILLSWITCH_METRIC_FILE}.tmp" "$OP_KILLSWITCH_METRIC_FILE" 2>/dev/null || true
+    chmod 644 "$OP_KILLSWITCH_METRIC_FILE" 2>/dev/null || true
+}
+
+# Trip the killswitch. Idempotent; does not reset the mtime if the lock
+# already exists so we do not extend the TTL unnecessarily.
+op_killswitch_trip() {
+    local reason="${1:-rate_limited}"
+    op_killswitch_init
+    if [[ ! -f "$OP_KILLSWITCH_LOCK" ]]; then
+        printf '%s trip_reason=%s\n' "$(date -u +%FT%TZ)" "$reason" > "$OP_KILLSWITCH_LOCK" 2>/dev/null || true
+        chmod 644 "$OP_KILLSWITCH_LOCK" 2>/dev/null || true
+        logger -t op-killswitch "1Password kill-switch TRIPPED: reason=${reason}. Further op calls are suppressed until TTL (${OP_KILLSWITCH_TTL_SECS}s) expires or the lock is removed."
+    fi
+    op_killswitch_write_metric 1 "$(stat -c %Y "$OP_KILLSWITCH_LOCK" 2>/dev/null || date +%s)"
+}
+
+# Scan a tmpfile from a recent op or ansible-playbook run for rate-limit
+# markers. If found, trip the killswitch.
+op_killswitch_scan_file() {
+    local file="$1"
+    [[ -f "$file" ]] || return 0
+    if grep -qiE 'Too many requests|rate[- ]limited|429 Too Many' "$file" 2>/dev/null; then
+        op_killswitch_trip "rate_limited"
+        return 0
+    fi
+    return 1
+}
+
+# Call this at the very top of any wrapper / helper that is about to
+# invoke `op`. If the killswitch is tripped, exit 0 silently (well, with
+# a syslog line) so automation does not compound the rate-limit window.
+op_killswitch_check_or_exit() {
+    if op_killswitch_is_active; then
+        logger -t op-killswitch "kill-switch active (lock $OP_KILLSWITCH_LOCK); skipping $(basename "${0:-unknown}")"
+        exit 0
+    fi
+}

--- a/scripts/lib/op-killswitch.sh
+++ b/scripts/lib/op-killswitch.sh
@@ -79,12 +79,26 @@ METRICS
     chmod 644 "$OP_KILLSWITCH_METRIC_FILE" 2>/dev/null || true
 }
 
-# Trip the killswitch. Idempotent; does not reset the mtime if the lock
-# already exists so we do not extend the TTL unnecessarily.
+# Trip the killswitch. If an active lock already exists (mtime within
+# TTL) we preserve its mtime so we do not extend the TTL on a flurry
+# of errors. If the lock is stale (mtime older than TTL) we overwrite
+# it so a new rate-limit event after the previous window expired gets
+# a fresh TTL, instead of leaving a stale one-shot lock that would
+# make op_killswitch_is_active report "inactive" and swallow the event.
 op_killswitch_trip() {
     local reason="${1:-rate_limited}"
     op_killswitch_init
-    if [[ ! -f "$OP_KILLSWITCH_LOCK" ]]; then
+    local refresh=1
+    if [[ -f "$OP_KILLSWITCH_LOCK" ]]; then
+        local existing_mtime age
+        existing_mtime=$(stat -c %Y "$OP_KILLSWITCH_LOCK" 2>/dev/null || echo 0)
+        age=$(( $(date +%s) - existing_mtime ))
+        if (( age < OP_KILLSWITCH_TTL_SECS )); then
+            # Lock is still within TTL; leave it alone, do not log again.
+            refresh=0
+        fi
+    fi
+    if (( refresh )); then
         printf '%s trip_reason=%s\n' "$(date -u +%FT%TZ)" "$reason" > "$OP_KILLSWITCH_LOCK" 2>/dev/null || true
         chmod 644 "$OP_KILLSWITCH_LOCK" 2>/dev/null || true
         logger -t op-killswitch "1Password kill-switch TRIPPED: reason=${reason}. Further op calls are suppressed until TTL (${OP_KILLSWITCH_TTL_SECS}s) expires or the lock is removed."

--- a/scripts/op-killswitch-status.sh
+++ b/scripts/op-killswitch-status.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Human-friendly status + manual override for the 1Password rate-limit
+# kill switch.
+#
+#   ./scripts/op-killswitch-status.sh          show current state
+#   ./scripts/op-killswitch-status.sh clear    remove the lock (manual)
+#   ./scripts/op-killswitch-status.sh trip     set the lock (debug/test)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/op-killswitch.sh
+source "${SCRIPT_DIR}/lib/op-killswitch.sh"
+
+cmd="${1:-status}"
+
+case "$cmd" in
+    status)
+        if op_killswitch_is_active; then
+            tripped=$(stat -c %Y "$OP_KILLSWITCH_LOCK" 2>/dev/null || echo 0)
+            age=$(( $(date +%s) - tripped ))
+            remaining=$(( OP_KILLSWITCH_TTL_SECS - age ))
+            echo "Killswitch: ACTIVE"
+            echo "  lock:      $OP_KILLSWITCH_LOCK"
+            echo "  tripped:   $(date -d @"$tripped" -u +%FT%TZ) ($(( age / 60 ))m ago)"
+            echo "  ttl:       ${OP_KILLSWITCH_TTL_SECS}s"
+            echo "  expires:   $(date -d @"$(( tripped + OP_KILLSWITCH_TTL_SECS ))" -u +%FT%TZ) (in $(( remaining / 60 ))m)"
+            echo "  reason:    $(cat "$OP_KILLSWITCH_LOCK" 2>/dev/null || echo '?')"
+            echo
+            echo "Clear manually once 1Password rate limit has cleared:"
+            echo "  $0 clear"
+            exit 1
+        else
+            echo "Killswitch: inactive (1Password calls allowed)"
+        fi
+        ;;
+    clear|off|unlock)
+        if [[ -f "$OP_KILLSWITCH_LOCK" ]]; then
+            rm -f "$OP_KILLSWITCH_LOCK"
+            op_killswitch_write_metric 0 0
+            echo "Killswitch cleared."
+        else
+            echo "Killswitch was not set; nothing to clear."
+        fi
+        ;;
+    trip|on|lock)
+        op_killswitch_trip "manual"
+        echo "Killswitch tripped manually."
+        ;;
+    *)
+        echo "Usage: $0 [status|clear|trip]" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/run-proxmox.sh
+++ b/scripts/run-proxmox.sh
@@ -10,10 +10,23 @@ PROM_FILE="${TEXTFILE_DIR}/ansible_run.prom"
 
 mkdir -p "$LOG_DIR" "$TEXTFILE_DIR"
 
+# shellcheck source=lib/op-killswitch.sh
+source "${REPO_DIR}/scripts/lib/op-killswitch.sh"
+# If 1P is currently rate-limited (known via the shared lock file),
+# skip this run entirely so we do not keep the rolling window pinned.
+op_killswitch_check_or_exit
+
 # Source 1Password service account token for dynamic inventory + vault
 export OP_SERVICE_ACCOUNT_TOKEN="${OP_SERVICE_ACCOUNT_TOKEN:-$(cat ~/.config/op/service-account-token 2>/dev/null || true)}"
 if [[ -n "$OP_SERVICE_ACCOUNT_TOKEN" ]] && command -v op &>/dev/null; then
-    export PROXMOX_TOKEN_SECRET="${PROXMOX_TOKEN_SECRET:-$(op read "op://Infrastructure/Proxmox API/Ansible Inventory/token_secret" 2>/dev/null || true)}"
+    op_err=$(mktemp)
+    token_value=$(op read "op://Infrastructure/Proxmox API/Ansible Inventory/token_secret" 2>"$op_err" || true)
+    if [[ -n "$token_value" ]]; then
+        export PROXMOX_TOKEN_SECRET="${PROXMOX_TOKEN_SECRET:-$token_value}"
+    else
+        op_killswitch_scan_file "$op_err" || true
+    fi
+    rm -f "$op_err"
 fi
 
 # Source ARA callback plugin environment (records runs to ARA database)
@@ -48,6 +61,10 @@ for playbook in proxmox.yml vm_baseline.yml monitoring.yml grafana_config.yml je
     rc=$?
     cat "$tmpfile" >> "$LOGFILE"
     playbook_results["${playbook}"]=$rc
+    # Any playbook that invoked `op read` and hit the rate limit puts
+    # "Too many requests" in its output. Surface that to the killswitch
+    # so subsequent scheduled runs short-circuit.
+    op_killswitch_scan_file "$tmpfile" || true
 
     # Parse PLAY RECAP for failed/unreachable hosts
     failed_hosts=""

--- a/scripts/run-security.sh
+++ b/scripts/run-security.sh
@@ -13,10 +13,23 @@ PROM_FILE="${TEXTFILE_DIR}/ansible_security.prom"
 
 mkdir -p "$LOG_DIR" "$TEXTFILE_DIR"
 
+# shellcheck source=lib/op-killswitch.sh
+source "${REPO_DIR}/scripts/lib/op-killswitch.sh"
+# If 1P is currently rate-limited (known via the shared lock file),
+# skip this run entirely so we do not keep the rolling window pinned.
+op_killswitch_check_or_exit
+
 # Source 1Password service account token for dynamic inventory + vault
 export OP_SERVICE_ACCOUNT_TOKEN="${OP_SERVICE_ACCOUNT_TOKEN:-$(cat ~/.config/op/service-account-token 2>/dev/null || true)}"
 if [[ -n "$OP_SERVICE_ACCOUNT_TOKEN" ]] && command -v op &>/dev/null; then
-    export PROXMOX_TOKEN_SECRET="${PROXMOX_TOKEN_SECRET:-$(op read "op://Infrastructure/Proxmox API/Ansible Inventory/token_secret" 2>/dev/null || true)}"
+    op_err=$(mktemp)
+    token_value=$(op read "op://Infrastructure/Proxmox API/Ansible Inventory/token_secret" 2>"$op_err" || true)
+    if [[ -n "$token_value" ]]; then
+        export PROXMOX_TOKEN_SECRET="${PROXMOX_TOKEN_SECRET:-$token_value}"
+    else
+        op_killswitch_scan_file "$op_err" || true
+    fi
+    rm -f "$op_err"
 fi
 
 # Source ARA callback plugin environment
@@ -45,6 +58,10 @@ for playbook in wazuh.yml crowdsec.yml; do
     rc=$?
     cat "$tmpfile" >> "$LOGFILE"
     playbook_results["${playbook}"]=$rc
+    # Any playbook that invoked `op read` and hit the rate limit puts
+    # "Too many requests" in its output. Surface that to the killswitch
+    # so subsequent scheduled runs short-circuit.
+    op_killswitch_scan_file "$tmpfile" || true
 
     failed_hosts=""
     if [[ $rc -ne 0 ]]; then

--- a/scripts/sync-prometheus-targets.sh
+++ b/scripts/sync-prometheus-targets.sh
@@ -11,14 +11,29 @@ set -euo pipefail
 LOG_PREFIX="[sync-prometheus-targets]"
 MIN_EXPECTED_TARGETS=10
 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/op-killswitch.sh
+source "${SCRIPT_DIR}/lib/op-killswitch.sh"
+# Skip this run entirely if 1P is rate-limited; dynamic inventory will
+# fall back to the cached Proxmox snapshot, so Prometheus targets stay
+# roughly correct while we wait out the window.
+op_killswitch_check_or_exit
+
 # Source 1Password service account token for dynamic inventory
 export OP_SERVICE_ACCOUNT_TOKEN="${OP_SERVICE_ACCOUNT_TOKEN:-$(cat ~/.config/op/service-account-token 2>/dev/null || true)}"
 if [[ -z "$OP_SERVICE_ACCOUNT_TOKEN" ]]; then
-    echo "${LOG_PREFIX} WARNING: OP_SERVICE_ACCOUNT_TOKEN is empty — dynamic inventory will not work" >&2
+    echo "${LOG_PREFIX} WARNING: OP_SERVICE_ACCOUNT_TOKEN is empty, dynamic inventory will not work" >&2
 fi
 
 if [[ -n "$OP_SERVICE_ACCOUNT_TOKEN" ]] && command -v op &>/dev/null; then
-    export PROXMOX_TOKEN_SECRET="${PROXMOX_TOKEN_SECRET:-$(op read "op://Infrastructure/Proxmox API/Ansible Inventory/token_secret" 2>/dev/null || true)}"
+    op_err=$(mktemp)
+    token_value=$(op read "op://Infrastructure/Proxmox API/Ansible Inventory/token_secret" 2>"$op_err" || true)
+    if [[ -n "$token_value" ]]; then
+        export PROXMOX_TOKEN_SECRET="${PROXMOX_TOKEN_SECRET:-$token_value}"
+    else
+        op_killswitch_scan_file "$op_err" || true
+    fi
+    rm -f "$op_err"
 fi
 
 if [[ -z "${PROXMOX_TOKEN_SECRET:-}" ]]; then

--- a/scripts/vault-pass.sh
+++ b/scripts/vault-pass.sh
@@ -1,18 +1,41 @@
 #!/usr/bin/env bash
 # Pulls Ansible vault password from 1Password.
-# Falls back to .vault_pass file if op CLI is unavailable.
+# Falls back to .vault_pass file if op CLI is unavailable OR the
+# 1Password rate-limit kill-switch is tripped.
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib/op-killswitch.sh
+source "${SCRIPT_DIR}/lib/op-killswitch.sh"
 
 export OP_SERVICE_ACCOUNT_TOKEN="${OP_SERVICE_ACCOUNT_TOKEN:-$(cat ~/.config/op/service-account-token 2>/dev/null || true)}"
 
-if [[ -n "$OP_SERVICE_ACCOUNT_TOKEN" ]] && command -v op &>/dev/null; then
-    op read "op://Infrastructure/Ansible Vault Password/password" 2>/dev/null && exit 0
-fi
-
-# Fallback to local file
-if [[ -f "$(dirname "$0")/../.vault_pass" ]]; then
-    cat "$(dirname "$0")/../.vault_pass"
-else
+# Fallback path used when op is unavailable, the killswitch is tripped,
+# or the op call fails for any reason.
+fallback_vault_pass() {
+    local vault_file="${SCRIPT_DIR}/../.vault_pass"
+    if [[ -f "$vault_file" ]]; then
+        cat "$vault_file"
+        exit 0
+    fi
     echo "ERROR: Cannot retrieve vault password from 1Password or .vault_pass" >&2
     exit 1
+}
+
+# Short-circuit to fallback if killswitch is active; do NOT call op.
+if op_killswitch_is_active; then
+    fallback_vault_pass
 fi
+
+if [[ -n "$OP_SERVICE_ACCOUNT_TOKEN" ]] && command -v op &>/dev/null; then
+    op_err=$(mktemp)
+    if op read "op://Infrastructure/Ansible Vault Password/password" 2>"$op_err"; then
+        rm -f "$op_err"
+        exit 0
+    fi
+    # op failed; check whether it was a rate-limit and trip the switch
+    op_killswitch_scan_file "$op_err" || true
+    rm -f "$op_err"
+fi
+
+fallback_vault_pass


### PR DESCRIPTION
## Summary

Closes the retry-storm problem seen on 2026-04-14. A burst of ~50 interactive \`op\` calls tripped the 1Password service-account rate limit, and the hourly \`run-proxmox.timer\` plus 30-minute \`run-security.timer\` kept the rolling-hour window pinned for 14+ hours because every scheduled firing made more \`op\` reads.

This PR adds a shared kill switch so the first script that sees "Too many requests" trips a lock, and every subsequent op-using script exits 0 silently while the lock is within its TTL.

## What's in this PR

### \`scripts/lib/op-killswitch.sh\` (new)
Sourced helper library.
- \`op_killswitch_is_active\`: returns 0 iff \`/var/lib/ansible-quasarlab/1p-killswitch\` exists and is younger than \`OP_KILLSWITCH_TTL_SECS\` (default 86400 = 1 day). Writes a Prometheus textfile metric every time it runs.
- \`op_killswitch_check_or_exit\`: call at the top of wrappers; exits 0 silently with a syslog line if the switch is tripped.
- \`op_killswitch_scan_file\`: grep an op or ansible-playbook tmpfile for rate-limit markers; trip if found.
- \`op_killswitch_trip\`: idempotent set (no TTL refresh on repeated calls).

### \`scripts/op-killswitch-status.sh\` (new, operator-facing)

\`\`\`
./scripts/op-killswitch-status.sh          # status
./scripts/op-killswitch-status.sh clear    # manual override
./scripts/op-killswitch-status.sh trip     # manual trip (debug)
\`\`\`

### Wired into all four op callers
- \`vault-pass.sh\`: skip op entirely when tripped, fall back to \`.vault_pass\`. Scan op stderr if it errors.
- \`run-proxmox.sh\`, \`run-security.sh\`: check at the top; scan each playbook tmpfile so a rate-limited sub-ansible run trips the switch for the next firing.
- \`sync-prometheus-targets.sh\`: check at top so inventory refreshes respect the switch.

## Metrics

Written to \`/var/lib/node_exporter/textfiles/onepassword_killswitch.prom\`:
- \`onepassword_killswitch_active\` (0 or 1)
- \`onepassword_killswitch_tripped_timestamp_seconds\`
- \`onepassword_killswitch_ttl_seconds\`

A follow-up PR in k8s-argocd will add a \`OnePasswordKillswitchActive\` alert that fires when this is 1 for more than a few minutes.

## Test plan

Done locally (see commit):
- library unit-ish exercise: simulate rate-limit tmpfile, confirm lock set, metric written, subshell exits 0.
- \`op-killswitch-status.sh\` prints inactive state cleanly when no lock exists.
- all scripts pass \`bash -n\`.

After merge:
- [ ] Deploy to command-center via existing scripts path (they already live under the repo, no role copy needed).
- [ ] \`./scripts/op-killswitch-status.sh trip\`, then run \`run-proxmox.sh\` manually; confirm it exits 0 immediately with a syslog line "kill-switch active".
- [ ] \`./scripts/op-killswitch-status.sh clear\`, confirm next run proceeds normally.

## Series context

This is **PR 1 of 3** in the op rate-limit hardening:
1. (this PR) Kill switch: stop the retry storm once a limit is hit.
2. Wrapper-level secret caching: fetch each secret once per run, pass via env, playbooks \`lookup('env', ...)\` instead of \`op read\`. Drops ~13/hr to ~1-3/hr.
3. Lower timer cadences: \`run-proxmox.timer\` 1h -> 4h, \`run-security.timer\` 30m -> 1h.