### PR TITLE
feat(scripts): cache 1Password secrets at wrapper layer (PR 2/3)

### DIFF
--- a/playbooks/authentik.yml
+++ b/playbooks/authentik.yml
@@ -3,43 +3,19 @@
   hosts: authentik
   become: true
   pre_tasks:
-    - name: Fetch Authentik credentials from 1Password
+    # Secrets are resolved from env vars populated by the wrapper's
+    # cached_op_read (see scripts/lib/op-secret-cache.sh). This skips
+    # four `op read` calls per playbook run in the common case. For
+    # direct `ansible-playbook` invocations outside the wrapper, set
+    # the env vars manually first.
+    - name: Resolve Authentik credentials from wrapper-cached env
       delegate_to: localhost
       become: false
-      block:
-        - name: Get PostgreSQL password
-          ansible.builtin.command:
-            cmd: op read "op://Infrastructure/Authentik/PostgreSQL Password"
-          register: op_pg_pass
-          changed_when: false
-          no_log: true
-
-        - name: Get Authentik secret key
-          ansible.builtin.command:
-            cmd: op read "op://Infrastructure/Authentik/Secret Key"
-          register: op_secret_key
-          changed_when: false
-          no_log: true
-
-        - name: Get Authentik admin bootstrap token
-          ansible.builtin.command:
-            cmd: op read "op://Infrastructure/Authentik/Admin Bootstrap Token"
-          register: op_admin_token
-          changed_when: false
-          no_log: true
-
-        - name: Get Authentik admin email
-          ansible.builtin.command:
-            cmd: op read "op://Infrastructure/Authentik/Admin Email"
-          register: op_admin_email
-          changed_when: false
-
-        - name: Set Authentik credential facts
-          ansible.builtin.set_fact:
-            authentik_db_password: "{{ op_pg_pass.stdout }}"
-            authentik_secret_key: "{{ op_secret_key.stdout }}"
-            authentik_admin_token: "{{ op_admin_token.stdout }}"
-            authentik_admin_email: "{{ op_admin_email.stdout }}"
-          no_log: true
+      ansible.builtin.set_fact:
+        authentik_db_password: "{{ lookup('env', 'AUTHENTIK_PG_PASSWORD') | mandatory }}"
+        authentik_secret_key: "{{ lookup('env', 'AUTHENTIK_SECRET_KEY') | mandatory }}"
+        authentik_admin_token: "{{ lookup('env', 'AUTHENTIK_ADMIN_BOOTSTRAP_TOKEN') | mandatory }}"
+        authentik_admin_email: "{{ lookup('env', 'AUTHENTIK_ADMIN_EMAIL') | mandatory }}"
+      no_log: true
   roles:
     - authentik

--- a/playbooks/postgresql.yml
+++ b/playbooks/postgresql.yml
@@ -5,20 +5,15 @@
   vars_files:
     - ../group_vars/vault.yml
   pre_tasks:
-    - name: Fetch PostgreSQL credentials from 1Password
+    # Secret resolved from env var populated by the wrapper's
+    # cached_op_read (see scripts/lib/op-secret-cache.sh). For direct
+    # `ansible-playbook` invocations outside the wrapper, set
+    # GRAFANA_PG_PASSWORD first.
+    - name: Resolve PostgreSQL credentials from wrapper-cached env
       delegate_to: localhost
       become: false
-      block:
-        - name: Get grafana DB password
-          ansible.builtin.command:
-            cmd: op read "op://Infrastructure/PostgreSQL Grafana DB/password"
-          register: op_grafana_db_pass
-          changed_when: false
-          no_log: true
-
-        - name: Set PostgreSQL credential facts
-          ansible.builtin.set_fact:
-            vault_postgresql_grafana_password: "{{ op_grafana_db_pass.stdout }}"
-          no_log: true
+      ansible.builtin.set_fact:
+        vault_postgresql_grafana_password: "{{ lookup('env', 'GRAFANA_PG_PASSWORD') | mandatory }}"
+      no_log: true
   roles:
     - postgresql

--- a/playbooks/wazuh.yml
+++ b/playbooks/wazuh.yml
@@ -5,36 +5,19 @@
   vars_files:
     - ../group_vars/vault.yml
   pre_tasks:
-    - name: Fetch Wazuh credentials from 1Password
+    # Secrets are resolved from env vars populated by the wrapper's
+    # cached_op_read (see scripts/lib/op-secret-cache.sh). For direct
+    # `ansible-playbook` invocations outside the wrapper, set these
+    # env vars first: WAZUH_PASSWORD, WAZUH_API_PASSWORD,
+    # WAZUH_INDEXER_ADMIN_PASSWORD.
+    - name: Resolve Wazuh credentials from wrapper-cached env
       delegate_to: localhost
       become: false
-      block:
-        - name: Get Wazuh dashboard admin password
-          ansible.builtin.command:
-            cmd: op read "op://Infrastructure/Wazuh SIEM/password"
-          register: op_wazuh_admin_pass
-          changed_when: false
-          no_log: true
-
-        - name: Get Wazuh API password
-          ansible.builtin.command:
-            cmd: op read "op://Infrastructure/Wazuh SIEM/API Credentials/api_password"
-          register: op_wazuh_api_pass
-          changed_when: false
-          no_log: true
-
-        - name: Get Wazuh indexer admin password
-          ansible.builtin.command:
-            cmd: op read "op://Infrastructure/Wazuh SIEM/Indexer/indexer_admin_password"
-          register: op_wazuh_indexer_pass
-          changed_when: false
-          no_log: true
-
-        - name: Set Wazuh credential facts
-          ansible.builtin.set_fact:
-            wazuh_admin_password: "{{ op_wazuh_admin_pass.stdout }}"
-            wazuh_api_password: "{{ op_wazuh_api_pass.stdout }}"
-            wazuh_indexer_password: "{{ op_wazuh_indexer_pass.stdout }}"
+      ansible.builtin.set_fact:
+        wazuh_admin_password: "{{ lookup('env', 'WAZUH_PASSWORD') | mandatory }}"
+        wazuh_api_password: "{{ lookup('env', 'WAZUH_API_PASSWORD') | mandatory }}"
+        wazuh_indexer_password: "{{ lookup('env', 'WAZUH_INDEXER_ADMIN_PASSWORD') | mandatory }}"
+      no_log: true
   roles:
     - wazuh_manager
 

--- a/scripts/lib/op-secret-cache.sh
+++ b/scripts/lib/op-secret-cache.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# File-backed cache for 1Password secret reads.
+#
+# Why: scheduled ansible runs, vault-pass, and per-playbook tasks each
+# fire `op read` calls whose values do not change between runs. Caching
+# them on disk with a TTL cuts the baseline `op read` rate from tens
+# per hour to a handful per day. Works with the kill switch (see
+# op-killswitch.sh): when the switch is tripped, cached values are
+# still served; we just never call `op` to refresh them.
+#
+# Usage (sourced):
+#     source "${SCRIPT_DIR}/lib/op-secret-cache.sh"
+#     value=$(cached_op_read proxmox_token "op://Infrastructure/Proxmox API/Ansible Inventory/token_secret")
+#
+# Cache file layout:
+#     /var/lib/ansible-quasarlab/secrets/<slug>     mode 0600, ladino-owned
+# The slug is any filesystem-safe name the caller picks. Contents are
+# the raw secret value with no trailing newline.
+#
+# TTL behavior:
+# - If cache file exists and is younger than OP_SECRET_CACHE_TTL_SECS
+#   (default 43200 = 12h), return it without calling op.
+# - If stale or missing, call op. On success, update the cache and
+#   return the new value. On op failure (rate limited, etc.):
+#     * if a stale cache exists, return it with a syslog warning.
+#     * if no cache exists at all, return empty string with rc=1 so
+#       the caller can decide how to handle the missing secret.
+# - The kill switch is checked first. If tripped, we do not call op
+#   at all (behaves like "stale cache, op unavailable").
+
+OP_SECRET_CACHE_DIR="${OP_SECRET_CACHE_DIR:-/var/lib/ansible-quasarlab/secrets}"
+OP_SECRET_CACHE_TTL_SECS="${OP_SECRET_CACHE_TTL_SECS:-43200}"
+
+# Depend on the kill-switch library already being sourced by the caller.
+# If it is not, define a stub so this library still works standalone.
+if ! declare -F op_killswitch_is_active >/dev/null; then
+    op_killswitch_is_active() { return 1; }
+    op_killswitch_scan_file() { return 1; }
+fi
+
+op_secret_cache_init() {
+    if [[ ! -d "$OP_SECRET_CACHE_DIR" ]]; then
+        mkdir -p "$OP_SECRET_CACHE_DIR" 2>/dev/null || true
+        chmod 0700 "$OP_SECRET_CACHE_DIR" 2>/dev/null || true
+    fi
+}
+
+# cached_op_read <slug> <op_path>
+# Echoes the secret value on stdout. Returns 0 on success, 1 if neither
+# a fresh nor stale cached value nor a live op read could produce one.
+cached_op_read() {
+    local slug="$1"
+    local op_path="$2"
+    local cache_file="${OP_SECRET_CACHE_DIR}/${slug}"
+    local now cache_age cache_fresh=0
+    now=$(date +%s)
+
+    op_secret_cache_init
+
+    if [[ -f "$cache_file" ]]; then
+        cache_age=$(( now - $(stat -c %Y "$cache_file" 2>/dev/null || echo 0) ))
+        if (( cache_age < OP_SECRET_CACHE_TTL_SECS )); then
+            cache_fresh=1
+        fi
+    fi
+
+    # Fresh cache: return immediately, no op call.
+    if (( cache_fresh )); then
+        cat "$cache_file"
+        return 0
+    fi
+
+    # Kill switch active: do not call op. Serve stale if we have it.
+    if op_killswitch_is_active; then
+        if [[ -f "$cache_file" ]]; then
+            logger -t op-secret-cache "killswitch active; serving stale cache for slug=${slug}"
+            cat "$cache_file"
+            return 0
+        fi
+        logger -t op-secret-cache "killswitch active AND no cache for slug=${slug}; returning empty"
+        return 1
+    fi
+
+    # Need a live read. Require op present and token set.
+    if ! command -v op >/dev/null 2>&1 || [[ -z "${OP_SERVICE_ACCOUNT_TOKEN:-}" ]]; then
+        if [[ -f "$cache_file" ]]; then
+            logger -t op-secret-cache "op unavailable; serving stale cache for slug=${slug}"
+            cat "$cache_file"
+            return 0
+        fi
+        return 1
+    fi
+
+    local op_err value
+    op_err=$(mktemp)
+    value=$(op read "$op_path" 2>"$op_err" || true)
+    if [[ -n "$value" ]]; then
+        # Write atomically with 0600 perms.
+        (
+            umask 0077
+            printf '%s' "$value" > "${cache_file}.tmp"
+        )
+        mv "${cache_file}.tmp" "$cache_file" 2>/dev/null || true
+        chmod 0600 "$cache_file" 2>/dev/null || true
+        rm -f "$op_err"
+        printf '%s' "$value"
+        return 0
+    fi
+
+    # op call failed. Scan for rate limit and trip the switch if so.
+    op_killswitch_scan_file "$op_err" || true
+    rm -f "$op_err"
+
+    if [[ -f "$cache_file" ]]; then
+        logger -t op-secret-cache "op failed; serving stale cache for slug=${slug}"
+        cat "$cache_file"
+        return 0
+    fi
+    return 1
+}
+
+# Pre-populate the env with a set of playbook secrets using the cache.
+# Called once at the top of each wrapper after the killswitch check.
+# Arguments: pairs of "<ENV_VAR> <slug> <op_path>" lines on stdin OR via
+# a here-doc. Using function arguments would be clearer but bash is
+# awkward about arrays with spaces in paths.
+#
+# Example:
+#     load_cached_secrets <<'EOF'
+#     PROXMOX_TOKEN_SECRET   proxmox_token           op://Infrastructure/Proxmox API/Ansible Inventory/token_secret
+#     AUTHENTIK_PG_PASSWORD  authentik_pg_password   op://Infrastructure/Authentik/PostgreSQL Password
+#     EOF
+load_cached_secrets() {
+    local env_name slug op_path value
+    while read -r env_name slug op_path; do
+        [[ -z "$env_name" || "$env_name" == \#* ]] && continue
+        if value=$(cached_op_read "$slug" "$op_path"); then
+            export "${env_name}=${value}"
+        else
+            logger -t op-secret-cache "load_cached_secrets: no value for ${env_name} (slug=${slug})"
+        fi
+    done
+}

--- a/scripts/run-proxmox.sh
+++ b/scripts/run-proxmox.sh
@@ -12,22 +12,28 @@ mkdir -p "$LOG_DIR" "$TEXTFILE_DIR"
 
 # shellcheck source=lib/op-killswitch.sh
 source "${REPO_DIR}/scripts/lib/op-killswitch.sh"
+# shellcheck source=lib/op-secret-cache.sh
+source "${REPO_DIR}/scripts/lib/op-secret-cache.sh"
 # If 1P is currently rate-limited (known via the shared lock file),
 # skip this run entirely so we do not keep the rolling window pinned.
 op_killswitch_check_or_exit
 
 # Source 1Password service account token for dynamic inventory + vault
 export OP_SERVICE_ACCOUNT_TOKEN="${OP_SERVICE_ACCOUNT_TOKEN:-$(cat ~/.config/op/service-account-token 2>/dev/null || true)}"
-if [[ -n "$OP_SERVICE_ACCOUNT_TOKEN" ]] && command -v op &>/dev/null; then
-    op_err=$(mktemp)
-    token_value=$(op read "op://Infrastructure/Proxmox API/Ansible Inventory/token_secret" 2>"$op_err" || true)
-    if [[ -n "$token_value" ]]; then
-        export PROXMOX_TOKEN_SECRET="${PROXMOX_TOKEN_SECRET:-$token_value}"
-    else
-        op_killswitch_scan_file "$op_err" || true
-    fi
-    rm -f "$op_err"
-fi
+
+# Pre-populate all secrets the downstream playbooks need. Each
+# cached_op_read call returns the cache value if it is fresh (TTL
+# default 12h), otherwise calls `op` once and updates the cache. This
+# collapses what used to be ~13 `op read` calls per run into 0 (all
+# cache hits) or ~8 (all cache misses, once per TTL window).
+load_cached_secrets <<'SECRETS'
+PROXMOX_TOKEN_SECRET             proxmox_token                      op://Infrastructure/Proxmox API/Ansible Inventory/token_secret
+AUTHENTIK_PG_PASSWORD            authentik_pg_password              op://Infrastructure/Authentik/PostgreSQL Password
+AUTHENTIK_SECRET_KEY             authentik_secret_key               op://Infrastructure/Authentik/Secret Key
+AUTHENTIK_ADMIN_BOOTSTRAP_TOKEN  authentik_admin_bootstrap_token    op://Infrastructure/Authentik/Admin Bootstrap Token
+AUTHENTIK_ADMIN_EMAIL            authentik_admin_email              op://Infrastructure/Authentik/Admin Email
+GRAFANA_PG_PASSWORD              grafana_pg_password                op://Infrastructure/PostgreSQL Grafana DB/password
+SECRETS
 
 # Source ARA callback plugin environment (records runs to ARA database)
 if [[ -f /etc/profile.d/ara-ansible-env.sh ]]; then

--- a/scripts/run-security.sh
+++ b/scripts/run-security.sh
@@ -15,22 +15,22 @@ mkdir -p "$LOG_DIR" "$TEXTFILE_DIR"
 
 # shellcheck source=lib/op-killswitch.sh
 source "${REPO_DIR}/scripts/lib/op-killswitch.sh"
+# shellcheck source=lib/op-secret-cache.sh
+source "${REPO_DIR}/scripts/lib/op-secret-cache.sh"
 # If 1P is currently rate-limited (known via the shared lock file),
 # skip this run entirely so we do not keep the rolling window pinned.
 op_killswitch_check_or_exit
 
 # Source 1Password service account token for dynamic inventory + vault
 export OP_SERVICE_ACCOUNT_TOKEN="${OP_SERVICE_ACCOUNT_TOKEN:-$(cat ~/.config/op/service-account-token 2>/dev/null || true)}"
-if [[ -n "$OP_SERVICE_ACCOUNT_TOKEN" ]] && command -v op &>/dev/null; then
-    op_err=$(mktemp)
-    token_value=$(op read "op://Infrastructure/Proxmox API/Ansible Inventory/token_secret" 2>"$op_err" || true)
-    if [[ -n "$token_value" ]]; then
-        export PROXMOX_TOKEN_SECRET="${PROXMOX_TOKEN_SECRET:-$token_value}"
-    else
-        op_killswitch_scan_file "$op_err" || true
-    fi
-    rm -f "$op_err"
-fi
+
+# Pre-populate secrets. See run-proxmox.sh for the rationale.
+load_cached_secrets <<'SECRETS'
+PROXMOX_TOKEN_SECRET             proxmox_token                       op://Infrastructure/Proxmox API/Ansible Inventory/token_secret
+WAZUH_PASSWORD                   wazuh_password                      op://Infrastructure/Wazuh SIEM/password
+WAZUH_API_PASSWORD               wazuh_api_password                  op://Infrastructure/Wazuh SIEM/API Credentials/api_password
+WAZUH_INDEXER_ADMIN_PASSWORD     wazuh_indexer_admin_password        op://Infrastructure/Wazuh SIEM/Indexer/indexer_admin_password
+SECRETS
 
 # Source ARA callback plugin environment
 if [[ -f /etc/profile.d/ara-ansible-env.sh ]]; then

--- a/scripts/vault-pass.sh
+++ b/scripts/vault-pass.sh
@@ -1,17 +1,21 @@
 #!/usr/bin/env bash
-# Pulls Ansible vault password from 1Password.
-# Falls back to .vault_pass file if op CLI is unavailable OR the
-# 1Password rate-limit kill-switch is tripped.
+# Pulls Ansible vault password from 1Password, via the wrapper secret
+# cache so each `ansible-playbook` invocation (which spawns this script)
+# does not hit 1Password every time.
+#
+# Falls back to .vault_pass file if op CLI is unavailable, the
+# 1Password rate-limit kill switch is tripped, or the cache and op
+# are both empty.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=lib/op-killswitch.sh
 source "${SCRIPT_DIR}/lib/op-killswitch.sh"
+# shellcheck source=lib/op-secret-cache.sh
+source "${SCRIPT_DIR}/lib/op-secret-cache.sh"
 
 export OP_SERVICE_ACCOUNT_TOKEN="${OP_SERVICE_ACCOUNT_TOKEN:-$(cat ~/.config/op/service-account-token 2>/dev/null || true)}"
 
-# Fallback path used when op is unavailable, the killswitch is tripped,
-# or the op call fails for any reason.
 fallback_vault_pass() {
     local vault_file="${SCRIPT_DIR}/../.vault_pass"
     if [[ -f "$vault_file" ]]; then
@@ -22,20 +26,12 @@ fallback_vault_pass() {
     exit 1
 }
 
-# Short-circuit to fallback if killswitch is active; do NOT call op.
-if op_killswitch_is_active; then
-    fallback_vault_pass
-fi
-
-if [[ -n "$OP_SERVICE_ACCOUNT_TOKEN" ]] && command -v op &>/dev/null; then
-    op_err=$(mktemp)
-    if op read "op://Infrastructure/Ansible Vault Password/password" 2>"$op_err"; then
-        rm -f "$op_err"
-        exit 0
-    fi
-    # op failed; check whether it was a rate-limit and trip the switch
-    op_killswitch_scan_file "$op_err" || true
-    rm -f "$op_err"
+# cached_op_read handles the kill-switch check, cache freshness, op
+# invocation, and stale-fallback internally. It returns rc=0 with the
+# value on stdout, or rc=1 when nothing is available at all.
+if value=$(cached_op_read ansible_vault_password "op://Infrastructure/Ansible Vault Password/password"); then
+    printf '%s' "$value"
+    exit 0
 fi
 
 fallback_vault_pass


### PR DESCRIPTION
## Summary

PR 2 of 3 in the op rate-limit hardening series (after #104 kill switch, before the timer-cadence tune). Cuts the steady-state \`op read\` count from ~25/hr across the two ansible timers to 0 on cache hits, or ~8/day (one read per secret per 12h TTL window) on cache misses.

Instead of each playbook task shelling out to \`op read\` for its own secret, wrappers now pre-populate all playbook secrets into env vars once per run via a file-backed cache. Playbooks just look the env vars up.

## What's in this PR

### \`scripts/lib/op-secret-cache.sh\` (new)
- \`cached_op_read <slug> <op_path>\`: returns value on stdout. Fresh cache = no op call. Stale/missing = one op call, then cache update. On op failure serves stale if present; trips the kill switch if it sees rate-limit markers.
- \`load_cached_secrets\`: reads env/slug/op_path triples on stdin, exports them all.
- Cache at \`/var/lib/ansible-quasarlab/secrets/\` (mode 0700, files 0600, ladino-owned). TTL default 12h, overridable via \`OP_SECRET_CACHE_TTL_SECS\`.
- Respects the kill switch from #104: when tripped, serves stale without calling op.

### Wrappers

| Wrapper | Secrets pre-populated |
|---|---|
| \`run-proxmox.sh\` | \`PROXMOX_TOKEN_SECRET\`, 4 Authentik secrets, \`GRAFANA_PG_PASSWORD\` |
| \`run-security.sh\` | \`PROXMOX_TOKEN_SECRET\`, 3 Wazuh secrets |
| \`vault-pass.sh\` | \`ansible_vault_password\` (the one called on every \`ansible-playbook\` invocation) |

### Playbooks
Three playbooks lose their \`ansible.builtin.command: op read ...\` tasks. Each now has a single \`set_fact\` that reads \`lookup('env', VAR) | mandatory\`. \`| mandatory\` ensures direct \`ansible-playbook\` invocations outside the wrapper fail loudly with a missing-var error instead of silently producing empty passwords.

- \`playbooks/authentik.yml\`: 4 op reads -> 1 env lookup block
- \`playbooks/wazuh.yml\`: 3 op reads -> 1 env lookup block
- \`playbooks/postgresql.yml\`: 1 op read -> 1 env lookup

## Expected impact

Before (steady state):
- run-proxmox (hourly): 1 + 4 + 1 secrets + 8 vault-pass = 14 reads
- run-security (30m): 1 + 3 + 2 vault-pass = 6 reads, x2/hr = 12/hr
- vault-pass elsewhere: 0 (only wrappers invoke ansible-playbook regularly)
- Total: ~26/hr

After:
- All 15 distinct cached slugs miss once every 12h = 30 reads / day = ~1.25/hr
- But in practice most runs will be cache hits
- Target: 0-3/hr

## Test plan

Local:
- [x] \`bash -n\` on all modified scripts
- [x] \`ansible-playbook --syntax-check\` on authentik.yml, wazuh.yml, postgresql.yml
- [x] Cache hit/miss/stale-fallback/killswitch-interaction unit tests (in commit description)

After merge:
- [ ] First run-proxmox / run-security after deploy shows cache files created with mode 0600 in /var/lib/ansible-quasarlab/secrets/
- [ ] Second run shows no \`op read\` invocations beyond the load_cached_secrets reads on cold cache
- [ ] Kill switch interaction: \`./scripts/op-killswitch-status.sh trip\`, next run completes using stale cache, no op calls
- [ ] Direct \`ansible-playbook playbooks/authentik.yml\` without env set: fails loudly on the mandatory filter (good).

## Series context

- PR 1 of 3 (#104, merged): kill switch.
- **PR 2 of 3 (this)**: wrapper-level secret caching.
- PR 3 of 3 (planned): lower timer cadences (run-proxmox 1h -> 4h, run-security 30m -> 1h) once this is stable.