### PR TITLE
fix(playbooks): fail-fast on empty env secrets (follow-up to #105)

### DIFF
--- a/playbooks/authentik.yml
+++ b/playbooks/authentik.yml
@@ -3,19 +3,39 @@
   hosts: authentik
   become: true
   pre_tasks:
-    # Secrets are resolved from env vars populated by the wrapper's
-    # cached_op_read (see scripts/lib/op-secret-cache.sh). This skips
-    # four `op read` calls per playbook run in the common case. For
-    # direct `ansible-playbook` invocations outside the wrapper, set
-    # the env vars manually first.
+    # Secrets come from env vars populated by the wrapper's
+    # cached_op_read (see scripts/lib/op-secret-cache.sh). The assert
+    # below fail-fasts when any of them is empty or unset, because
+    # `lookup('env', X) | mandatory` would pass an empty string
+    # through silently (the env lookup is always defined, mandatory
+    # only catches undefined). For direct `ansible-playbook` runs
+    # outside the wrapper, export AUTHENTIK_PG_PASSWORD,
+    # AUTHENTIK_SECRET_KEY, AUTHENTIK_ADMIN_BOOTSTRAP_TOKEN,
+    # AUTHENTIK_ADMIN_EMAIL first.
+    - name: Assert wrapper-cached Authentik env is populated
+      delegate_to: localhost
+      become: false
+      ansible.builtin.assert:
+        that:
+          - lookup('env', 'AUTHENTIK_PG_PASSWORD')           | length > 0
+          - lookup('env', 'AUTHENTIK_SECRET_KEY')            | length > 0
+          - lookup('env', 'AUTHENTIK_ADMIN_BOOTSTRAP_TOKEN') | length > 0
+          - lookup('env', 'AUTHENTIK_ADMIN_EMAIL')           | length > 0
+        fail_msg: >-
+          One or more required env vars are empty or unset. Run via
+          scripts/run-proxmox.sh (which calls load_cached_secrets) or
+          export AUTHENTIK_PG_PASSWORD, AUTHENTIK_SECRET_KEY,
+          AUTHENTIK_ADMIN_BOOTSTRAP_TOKEN, AUTHENTIK_ADMIN_EMAIL first.
+        quiet: true
+
     - name: Resolve Authentik credentials from wrapper-cached env
       delegate_to: localhost
       become: false
       ansible.builtin.set_fact:
-        authentik_db_password: "{{ lookup('env', 'AUTHENTIK_PG_PASSWORD') | mandatory }}"
-        authentik_secret_key: "{{ lookup('env', 'AUTHENTIK_SECRET_KEY') | mandatory }}"
-        authentik_admin_token: "{{ lookup('env', 'AUTHENTIK_ADMIN_BOOTSTRAP_TOKEN') | mandatory }}"
-        authentik_admin_email: "{{ lookup('env', 'AUTHENTIK_ADMIN_EMAIL') | mandatory }}"
+        authentik_db_password: "{{ lookup('env', 'AUTHENTIK_PG_PASSWORD') }}"
+        authentik_secret_key: "{{ lookup('env', 'AUTHENTIK_SECRET_KEY') }}"
+        authentik_admin_token: "{{ lookup('env', 'AUTHENTIK_ADMIN_BOOTSTRAP_TOKEN') }}"
+        authentik_admin_email: "{{ lookup('env', 'AUTHENTIK_ADMIN_EMAIL') }}"
       no_log: true
   roles:
     - authentik

--- a/playbooks/postgresql.yml
+++ b/playbooks/postgresql.yml
@@ -5,15 +5,28 @@
   vars_files:
     - ../group_vars/vault.yml
   pre_tasks:
-    # Secret resolved from env var populated by the wrapper's
-    # cached_op_read (see scripts/lib/op-secret-cache.sh). For direct
-    # `ansible-playbook` invocations outside the wrapper, set
+    # Secret comes from env var populated by the wrapper's
+    # cached_op_read (see scripts/lib/op-secret-cache.sh). The assert
+    # below fail-fasts on empty values because `lookup('env', X) |
+    # mandatory` would pass an empty string through silently. For
+    # direct `ansible-playbook` runs outside the wrapper, export
     # GRAFANA_PG_PASSWORD first.
+    - name: Assert wrapper-cached PostgreSQL env is populated
+      delegate_to: localhost
+      become: false
+      ansible.builtin.assert:
+        that:
+          - lookup('env', 'GRAFANA_PG_PASSWORD') | length > 0
+        fail_msg: >-
+          GRAFANA_PG_PASSWORD is empty or unset. Run via
+          scripts/run-proxmox.sh or export it first.
+        quiet: true
+
     - name: Resolve PostgreSQL credentials from wrapper-cached env
       delegate_to: localhost
       become: false
       ansible.builtin.set_fact:
-        vault_postgresql_grafana_password: "{{ lookup('env', 'GRAFANA_PG_PASSWORD') | mandatory }}"
+        vault_postgresql_grafana_password: "{{ lookup('env', 'GRAFANA_PG_PASSWORD') }}"
       no_log: true
   roles:
     - postgresql

--- a/playbooks/wazuh.yml
+++ b/playbooks/wazuh.yml
@@ -5,18 +5,34 @@
   vars_files:
     - ../group_vars/vault.yml
   pre_tasks:
-    # Secrets are resolved from env vars populated by the wrapper's
-    # cached_op_read (see scripts/lib/op-secret-cache.sh). For direct
-    # `ansible-playbook` invocations outside the wrapper, set these
-    # env vars first: WAZUH_PASSWORD, WAZUH_API_PASSWORD,
-    # WAZUH_INDEXER_ADMIN_PASSWORD.
+    # Secrets come from env vars populated by the wrapper's
+    # cached_op_read (see scripts/lib/op-secret-cache.sh). The assert
+    # below fail-fasts on empty values because `lookup('env', X) |
+    # mandatory` would pass an empty string through silently. For
+    # direct `ansible-playbook` runs outside the wrapper, export
+    # WAZUH_PASSWORD, WAZUH_API_PASSWORD, WAZUH_INDEXER_ADMIN_PASSWORD
+    # first.
+    - name: Assert wrapper-cached Wazuh env is populated
+      delegate_to: localhost
+      become: false
+      ansible.builtin.assert:
+        that:
+          - lookup('env', 'WAZUH_PASSWORD')               | length > 0
+          - lookup('env', 'WAZUH_API_PASSWORD')           | length > 0
+          - lookup('env', 'WAZUH_INDEXER_ADMIN_PASSWORD') | length > 0
+        fail_msg: >-
+          One or more required env vars are empty or unset. Run via
+          scripts/run-security.sh or export WAZUH_PASSWORD,
+          WAZUH_API_PASSWORD, WAZUH_INDEXER_ADMIN_PASSWORD first.
+        quiet: true
+
     - name: Resolve Wazuh credentials from wrapper-cached env
       delegate_to: localhost
       become: false
       ansible.builtin.set_fact:
-        wazuh_admin_password: "{{ lookup('env', 'WAZUH_PASSWORD') | mandatory }}"
-        wazuh_api_password: "{{ lookup('env', 'WAZUH_API_PASSWORD') | mandatory }}"
-        wazuh_indexer_password: "{{ lookup('env', 'WAZUH_INDEXER_ADMIN_PASSWORD') | mandatory }}"
+        wazuh_admin_password: "{{ lookup('env', 'WAZUH_PASSWORD') }}"
+        wazuh_api_password: "{{ lookup('env', 'WAZUH_API_PASSWORD') }}"
+        wazuh_indexer_password: "{{ lookup('env', 'WAZUH_INDEXER_ADMIN_PASSWORD') }}"
       no_log: true
   roles:
     - wazuh_manager


### PR DESCRIPTION
## Summary

Follow-up to the merged #105. Codex correctly flagged that \`lookup('env', X) | mandatory\` does NOT reject empty strings, only undefined values. The fix didn't land in #105 before merge, so this is a standalone PR.

## The bug

\`lookup('env', ...)\` always returns a string. If the variable is unset, it returns \`""\`. \`mandatory\` only errors on undefined values, so the pipeline \`lookup('env', X) | mandatory\` passes empty strings through silently, and downstream roles can end up applying blank passwords / tokens.

Scenarios where this would bite:
- Direct \`ansible-playbook playbooks/authentik.yml\` without the wrapper.
- Wrapper run where \`cached_op_read\` returned empty (no cache, no fresh op because the kill switch is tripped).
- A typo in a wrapper env var name.

## Change

Add an explicit \`ansible.builtin.assert\` before each \`set_fact\` with \`that: - lookup('env', X) | length > 0\`. Fail message points at the correct wrapper or env-var export path so the operator knows what's missing.

Affects:
- \`playbooks/authentik.yml\` (4 env vars)
- \`playbooks/wazuh.yml\` (3 env vars)
- \`playbooks/postgresql.yml\` (1 env var)

All three pass \`ansible-playbook --syntax-check\`. Asserts are \`quiet: true\` so secret values never appear in logs even when the assertion fails.

## Verification

\`\`\`
$ unset AUTHENTIK_PG_PASSWORD
$ ansible localhost -m assert \\
    -a "that='lookup(\"env\",\"AUTHENTIK_PG_PASSWORD\") | length > 0' fail_msg=empty quiet=true"
localhost | FAILED! => {
    "assertion": "lookup(\"env\",\"AUTHENTIK_PG_PASSWORD\") | length > 0",
    "changed": false,
    "evaluated_to": false,
    "msg": "empty"
}
\`\`\`

Exactly the fail-fast behavior we want, matching what the original \`op read\` tasks gave us.