### PR TITLE
docs(cmd-center): add spec for DR provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ group_vars/vault.yml
 inventory-cache.ini
 __pycache__/
 *.pyc
+.mcp.json

--- a/.spec-workflow/specs/cmd-center-dr-provisioning/design.md
+++ b/.spec-workflow/specs/cmd-center-dr-provisioning/design.md
@@ -1,0 +1,147 @@
+# Design: cmd-center1 DR Provisioning
+
+## Overview
+
+Extend the existing `roles/cmd_center/` role to cover all currently-manual provisioning steps. The new tasks are organized into topical task files included from `main.yml`, preserving the existing logic while adding new capabilities.
+
+## Architectural Decisions
+
+### Decision 1: Extend existing role, do not create a new role
+
+The existing `cmd_center` role already targets the same host, owns kubectl config setup, and deploys the ansible-proxmox/security systemd timers. Creating a new role would require duplicate inventory entries, group_vars, and risk ordering bugs. Extending keeps related concerns co-located.
+
+**Rejected alternative:** Split into `cmd_center_base` and `cmd_center_apps`. This adds indirection without clear ownership benefit for a single-host role.
+
+### Decision 2: Standalone Node 22 binary at `~/.local/lib/nodejs/`
+
+Ubuntu 24.04 ships Node 18.19.1 via apt. The spec-workflow-mcp dashboard requires Node 20+ (vite 8, tailwindcss/oxide, find-my-way all refuse Node 18). Installing Node 22 via NodeSource apt repo would replace the system Node, potentially breaking other apt packages that depend on node-18. A standalone tarball install in `~/.local/lib/nodejs/` isolates Node 22 to the user scope without touching system state.
+
+**Rejected alternatives:**
+- **nvm**: Adds another tool to the bootstrap chain, slower shell startup, harder to drive from systemd
+- **nodesource apt repo**: Replaces system Node, broader blast radius
+- **fnm**: Same objections as nvm
+
+### Decision 3: systemd user service (not system) for spec-workflow
+
+The dashboard runs as `ladino` and reads files under `~/.claude` and `~/code`. A system service would either require running as root (against security-first directive) or would need User= and StateDirectory= setup. A user service is simpler and matches "runs as the login user" semantics. Requires `loginctl enable-linger ladino` so it survives logout and starts at boot.
+
+**Rejected alternative:** system service with `User=ladino`. Works, but requires careful tmpfiles.d config for writable paths, and does not inherit user env.
+
+### Decision 4: 1Password service account token via ansible-vault
+
+The `op` CLI needs a service account token at `~/.op_service_account_token` to unlock 1P and fetch SSH keys, kubeconfig, etc. This is the bootstrap secret that all other secret retrievals depend on. Storing it in ansible-vault keeps the playbook self-contained: operator runs `ansible-playbook --ask-vault-pass` and the token is decrypted and written to disk.
+
+**Rejected alternative:** Operator manually creates the token file. Works but breaks the "single playbook run" goal.
+
+### Decision 5: Git SSH over HTTPS
+
+All git clones use `git@github.com:...` URLs. The SSH key deployed from 1P provides both authentication (clone) and push (for writing back memory updates). Using HTTPS would require either a PAT in 1P or leaving the repo read-only.
+
+### Decision 6: Clone order with claude-config first
+
+`claude-config` must be cloned before any other repo because:
+1. `bin/bootstrap.sh` creates the `~/.claude/` symlinks (memory, settings, etc.)
+2. The memory symlinks must exist before Claude Code sessions can write to them
+3. Lab repos' `.mcp.json` files may reference paths that depend on `~/.claude/` setup
+
+## Task File Structure
+
+```
+roles/cmd_center/
+├── tasks/
+│   ├── main.yml              # orchestrator: include_tasks in order
+│   ├── packages.yml          # apt deps (extracted from current main.yml)
+│   ├── cli_tools.yml         # NEW: helm, yq, gh, terraform (op handled by onepassword_cli role)
+│   ├── onepassword_token.yml # NEW: write the 1P service account token from vault
+│   ├── ssh_keys.yml          # NEW: fetch SSH key from 1P via op, deploy to ~/.ssh
+│   ├── linger.yml            # NEW: enable systemd linger for ladino
+│   ├── git_repos.yml         # NEW: clone claude-config + lab repos
+│   ├── claude_bootstrap.yml  # NEW: run claude-config/bin/bootstrap.sh
+│   ├── node_runtime.yml      # NEW: Node 22 standalone install
+│   ├── spec_workflow.yml     # NEW: systemd user unit for dashboard
+│   ├── kubeconfig.yml        # existing kubectl fetch (extracted)
+│   └── ansible_timers.yml    # existing proxmox/security timers (extracted)
+├── templates/
+│   ├── spec-workflow-dashboard.service.j2    # NEW
+│   ├── ansible-proxmox.service.j2            # existing
+│   ├── ansible-proxmox.timer.j2              # existing
+│   ├── ansible-security.service.j2           # existing
+│   └── ansible-security.timer.j2             # existing
+├── handlers/main.yml         # existing
+└── defaults/main.yml         # extend with new variables
+```
+
+## Orchestration Order
+
+The `main.yml` orchestrator must execute task files in strict dependency order:
+
+```yaml
+- include_tasks: packages.yml          # apt deps for everything below
+- include_tasks: cli_tools.yml         # helm, yq, gh (some use apt)
+- include_tasks: onepassword_token.yml # the bootstrap secret
+- include_tasks: ssh_keys.yml          # depends on op token
+- include_tasks: linger.yml            # independent
+- include_tasks: git_repos.yml         # depends on SSH keys
+- include_tasks: claude_bootstrap.yml  # depends on claude-config repo cloned
+- include_tasks: node_runtime.yml      # independent
+- include_tasks: spec_workflow.yml     # depends on node + linger
+- include_tasks: kubeconfig.yml        # existing, depends on k8s nodes being up
+- include_tasks: ansible_timers.yml    # existing, depends on repo cloned
+```
+
+## Key Variables
+
+`defaults/main.yml` additions:
+
+```yaml
+node_version: "22.16.0"
+node_install_dir: "/home/{{ ansible_user }}/.local/lib/nodejs"
+lab_repos:
+  - { name: claude-config,              url: "git@github.com:mithr4ndir/claude-config.git" }
+  - { name: k8s-argocd,                 url: "git@github.com:mithr4ndir/k8s-argocd.git" }
+  - { name: ansible-quasarlab,          url: "git@github.com:mithr4ndir/ansible-quasarlab.git" }
+  - { name: observability-quasarlab,    url: "git@github.com:mithr4ndir/observability-quasarlab.git" }
+  - { name: terraform-quasarlab,        url: "git@github.com:mithr4ndir/terraform-quasarlab.git" }
+  - { name: quasarlab-disaster-recovery, url: "git@github.com:mithr4ndir/quasarlab-disaster-recovery.git" }
+  - { name: truenas-config-backup,      url: "git@github.com:mithr4ndir/truenas-config-backup.git" }
+spec_workflow_port: 5000
+spec_workflow_bind_address: "0.0.0.0"
+spec_workflow_cors_enabled: false
+```
+
+## Idempotency Design
+
+| Task | Idempotency mechanism |
+|------|----------------------|
+| apt install | Ansible `apt:` module native |
+| Node 22 download | `creates: {{ node_install_dir }}/node-v{{ node_version }}-linux-x64/bin/node` |
+| Node 22 symlink | `file: state=link force=yes` |
+| Git clone | `git: update=no` (does not force-pull) |
+| Claude bootstrap | Script itself is idempotent (checks before creating symlinks) |
+| Systemd unit deploy | Template with handler only on change |
+| Linger | Check `/var/lib/systemd/linger/{{ ansible_user }}` before running |
+| SSH key deployment | `no_log: true`, compare checksum before write |
+
+## Security Considerations
+
+1. **1P token file permissions**: `0600`, owner `ladino`, group `ladino`
+2. **SSH private keys**: same as above
+3. **`no_log: true`** on any task that handles secret content
+4. **Ansible vault**: use `--ask-vault-pass` or vault password file (in 1P, manually retrieved)
+5. **Service account token scope**: the 1P service account should have read-only access to the Infrastructure vault, not the master
+
+## Verification (post-run)
+
+```yaml
+# tasks/verify.yml (optional final step)
+- assert: that = "{{ lookup('url', 'http://127.0.0.1:5000', timeout=10) is defined }}"
+- command: kubectl get nodes
+- command: test -L "{{ ansible_user_dir }}/.claude/memory"
+- command: test -L "{{ ansible_user_dir }}/.claude/projects/-home-ladino/memory"
+```
+
+## Open Questions
+
+1. Should the playbook also install VS Code Server (for Remote SSH) or is that operator-initiated?
+2. Should `cmd-center1` host its own sync-to-claude-config cron, or is that covered by the bootstrap symlink approach?
+3. Do we need to support multiple command center hosts in the future (e.g., a laptop running the same setup)?

--- a/.spec-workflow/specs/cmd-center-dr-provisioning/requirements.md
+++ b/.spec-workflow/specs/cmd-center-dr-provisioning/requirements.md
@@ -1,0 +1,89 @@
+# Requirements: cmd-center1 DR Provisioning
+
+## Introduction
+
+Currently, cmd-center1 (the host running Claude Code sessions, spec-workflow dashboard, and the Ansible/K8s control plane) is only partially provisioned by the existing `cmd_center` Ansible role. Critical components (Node 22, spec-workflow dashboard, Claude Code memory symlinks, lab repo clones, CLI tools, SSH keys) are configured manually. If the host dies, rebuilding takes hours of manual work and risks losing session continuity.
+
+This spec extends the existing `cmd_center` role so a fresh Ubuntu 24.04 host becomes a fully working command center via a single Ansible playbook run.
+
+## Requirements
+
+### Requirement 1: Fully Automated Provisioning
+
+**User Story:** As a homelab operator, I want a single Ansible playbook run to fully provision cmd-center1, so that I can recover from host failure without manual tool installation.
+
+#### Acceptance Criteria
+
+1. WHEN a fresh Ubuntu 24.04 host is available with user `ladino` and SSH access THEN the `site.yml` playbook SHALL provision it to a fully working state
+2. IF the playbook runs successfully THEN all tools (kubectl, helm, yq, jq, gh, terraform, op, ansible, Node 22) SHALL be installed and on PATH
+3. WHEN provisioning completes THEN the spec-workflow dashboard SHALL be running and reachable at http://<host>:5000
+4. IF the host reboots THEN all services SHALL come back up automatically without manual intervention
+
+### Requirement 2: Idempotency
+
+**User Story:** As a homelab operator, I want to re-run the playbook safely on an already-provisioned host, so that I can apply config updates without fear of breaking existing state.
+
+#### Acceptance Criteria
+
+1. WHEN the playbook runs on a fully provisioned host THEN it SHALL make zero changes (all tasks report `ok`)
+2. IF a git repo is already cloned THEN the task SHALL NOT force-update it to avoid clobbering local work
+3. WHEN Node 22 is already installed at the expected version THEN the task SHALL skip re-download
+
+### Requirement 3: Secrets Management
+
+**User Story:** As a homelab operator, I want secrets (1Password service account token, SSH keys) handled securely, so that they never appear in plaintext in git or logs.
+
+#### Acceptance Criteria
+
+1. WHEN the 1Password service account token is deployed THEN it SHALL be sourced from ansible-vault or pulled from 1P at runtime
+2. IF SSH keys are deployed THEN they SHALL be fetched from 1P using the `op` CLI, not committed to the repo
+3. WHEN logs are written THEN secrets SHALL NOT appear in Ansible output (use `no_log: true` where appropriate)
+
+### Requirement 4: Persistent Memory
+
+**User Story:** As a homelab operator, I want Claude Code memory (auto-memory and memory-bank) symlinked to the claude-config git repo, so that session knowledge survives host rebuilds.
+
+#### Acceptance Criteria
+
+1. WHEN the playbook completes THEN `~/.claude/projects/-home-ladino/memory` SHALL symlink to `~/code/claude-config/memory`
+2. WHEN the playbook completes THEN `~/.claude/memory` SHALL symlink to `~/code/claude-config/memory`
+3. IF the symlinks already exist correctly THEN the task SHALL NOT recreate them
+
+### Requirement 5: Service Auto-Start
+
+**User Story:** As a homelab operator, I want all user services to start on boot without login, so that cmd-center1 works after a power cycle.
+
+#### Acceptance Criteria
+
+1. WHEN the playbook runs THEN `loginctl enable-linger ladino` SHALL be executed (idempotent)
+2. WHEN the spec-workflow-dashboard.service unit is installed THEN it SHALL be enabled at `default.target`
+3. IF the host reboots THEN the dashboard SHALL be reachable within 60 seconds without login
+
+### Requirement 6: Bootstrap Prereqs Documented
+
+**User Story:** As a homelab operator, I want the manual bootstrap prereqs documented, so that I know exactly what steps to perform before running the playbook.
+
+#### Acceptance Criteria
+
+1. WHEN the README is read THEN it SHALL list the exact manual steps required before the first playbook run
+2. IF a user follows the prereqs THEN they SHALL result in an Ansible-reachable host
+
+## Non-Functional Requirements
+
+### Recovery Time Objective (RTO)
+- Total time from fresh Ubuntu install to fully working cmd-center1: under 30 minutes (excluding Ubuntu install time itself)
+
+### Compatibility
+- Target OS: Ubuntu 24.04 (Noble)
+- Target user: ladino (non-root, with sudo via NOPASSWD for specific commands)
+- Ansible runner: can be another Linux host with SSH access, or cmd-center1 running against itself
+
+### Scope Exclusions
+- SSH server hardening (handled by separate `common` role)
+- VS Code Server or VS Code Remote SSH setup (handled manually by user)
+- GPU or hardware-specific config (cmd-center1 is a simple VM)
+
+## References
+- Existing role: `roles/cmd_center/`
+- Bootstrap script: `~/code/claude-config/bin/bootstrap.sh`
+- Related: `roles/onepassword_cli/` (may already handle `op` install)

--- a/.spec-workflow/specs/cmd-center-dr-provisioning/tasks.md
+++ b/.spec-workflow/specs/cmd-center-dr-provisioning/tasks.md
@@ -1,0 +1,156 @@
+# Tasks: cmd-center1 DR Provisioning
+
+## Phase 1: Refactor existing role
+
+- [ ] 1. Extract existing logic into topical task files
+  - Split `roles/cmd_center/tasks/main.yml` into `packages.yml`, `kubeconfig.yml`, `ansible_timers.yml`
+  - Rewrite `main.yml` to be a pure orchestrator using `include_tasks`
+  - Verify existing functionality still works: run playbook with `--check` mode against live cmd-center1, confirm zero unexpected changes
+  - _Requirements: 2_
+
+## Phase 2: New task files (dependencies first)
+
+- [ ] 2. Add CLI tools installation
+  - File: `roles/cmd_center/tasks/cli_tools.yml`
+  - Install via apt where available: `jq`, `gh` (via hashicorp GPG key + repo), `yq` (binary from GitHub releases if not in apt)
+  - Install `helm` via helm.sh script or binary tarball
+  - Install `terraform` via hashicorp apt repo
+  - Verify `op` is handled by the existing `onepassword_cli` role (include it as a role dependency if needed)
+  - _Requirements: 1_
+
+- [ ] 3. Add 1Password service account token deployment
+  - File: `roles/cmd_center/tasks/onepassword_token.yml`
+  - Create the ansible-vault encrypted variable `op_service_account_token` in `group_vars/cmd_center/vault.yml`
+  - Task copies the decrypted token to `/home/{{ ansible_user }}/.op_service_account_token`, mode `0600`, `no_log: true`
+  - Verify `op --version` works after deploy
+  - _Requirements: 3_
+
+- [ ] 4. Add SSH key deployment via 1P
+  - File: `roles/cmd_center/tasks/ssh_keys.yml`
+  - Use `op read` to fetch the SSH private key from 1P Infrastructure vault
+  - Write to `~/.ssh/id_ed25519` with mode `0600`
+  - Write the public key to `~/.ssh/id_ed25519.pub` with mode `0644`
+  - Configure `~/.ssh/known_hosts` with `github.com` host key (ssh-keyscan)
+  - `no_log: true` on all secret-handling tasks
+  - _Requirements: 3_
+
+- [ ] 5. Add systemd linger enablement
+  - File: `roles/cmd_center/tasks/linger.yml`
+  - Check `/var/lib/systemd/linger/{{ ansible_user }}` existence first (idempotency guard)
+  - Run `loginctl enable-linger {{ ansible_user }}` if not present
+  - Requires `become: true`
+  - _Requirements: 5_
+
+## Phase 3: New task files (application layer)
+
+- [ ] 6. Add git repo cloning
+  - File: `roles/cmd_center/tasks/git_repos.yml`
+  - Loop over `lab_repos` variable
+  - Clone `claude-config` FIRST, then others (order-sensitive due to claude-config bootstrap)
+  - Use `git: update=no` to avoid clobbering local work on re-runs
+  - Target directory: `/home/{{ ansible_user }}/code/{{ item.name }}`
+  - _Requirements: 1, 2_
+
+- [ ] 7. Add Claude config bootstrap
+  - File: `roles/cmd_center/tasks/claude_bootstrap.yml`
+  - Run `~/code/claude-config/bin/bootstrap.sh`
+  - The script is idempotent: it checks for existing symlinks before creating
+  - Verify: `~/.claude/memory` is a symlink to `~/code/claude-config/memory`
+  - Verify: `~/.claude/projects/-home-ladino/memory` is a symlink to `~/code/claude-config/memory`
+  - _Requirements: 4_
+
+- [ ] 8. Add Node 22 standalone install
+  - File: `roles/cmd_center/tasks/node_runtime.yml`
+  - Download `node-v{{ node_version }}-linux-x64.tar.xz` from nodejs.org
+  - Extract to `/home/{{ ansible_user }}/.local/lib/nodejs/`
+  - Create symlink `current` pointing to the versioned directory
+  - Use `creates:` argument for idempotency
+  - Verify `~/.local/lib/nodejs/current/bin/node --version` returns the expected version
+  - _Requirements: 1, 2_
+
+- [ ] 9. Add spec-workflow dashboard service
+  - File: `roles/cmd_center/tasks/spec_workflow.yml`
+  - Template: `roles/cmd_center/templates/spec-workflow-dashboard.service.j2`
+  - Deploy unit to `~/.config/systemd/user/spec-workflow-dashboard.service`
+  - Notify handler: systemctl --user daemon-reload + restart
+  - Enable and start: `systemd: name=spec-workflow-dashboard scope=user enabled=true state=started`
+  - Verify: `curl http://127.0.0.1:5000` returns HTTP 200
+  - _Requirements: 1, 5_
+
+## Phase 4: Orchestration and variables
+
+- [ ] 10. Rewrite main.yml as orchestrator
+  - File: `roles/cmd_center/tasks/main.yml`
+  - Sequence per design.md Orchestration Order section
+  - Each line is `- include_tasks: <filename>`
+  - Add tags per task file (e.g., `tags: [packages]`, `tags: [node]`) for selective runs
+  - _Requirements: 1_
+
+- [ ] 11. Update defaults
+  - File: `roles/cmd_center/defaults/main.yml`
+  - Add: `node_version`, `node_install_dir`, `lab_repos`, `spec_workflow_port`, `spec_workflow_bind_address`, `spec_workflow_cors_enabled`
+  - Preserve existing `ansible_repo_path` variable
+  - _Requirements: 1_
+
+- [ ] 12. Add handler for user systemd reload
+  - File: `roles/cmd_center/handlers/main.yml`
+  - Add handler: `Reload user systemd` running `systemctl --user daemon-reload`
+  - Add handler: `Restart spec-workflow-dashboard` running `systemctl --user restart spec-workflow-dashboard`
+  - _Requirements: 1_
+
+## Phase 5: Secrets and vault setup
+
+- [ ] 13. Create vault file for cmd_center secrets
+  - File: `group_vars/cmd_center/vault.yml` (ansible-vault encrypted)
+  - Variables: `op_service_account_token` (read-only token for Infrastructure vault)
+  - Document vault password retrieval in README
+  - _Requirements: 3_
+
+- [ ] 14. Document manual prereqs
+  - File: `roles/cmd_center/README.md` (create if missing) or update main project README
+  - List: Ubuntu 24.04 fresh install, `ladino` user with sudo, initial SSH key for Ansible runner, ansible-vault password
+  - Reference 1P item paths for SSH keys, op service account token
+  - _Requirements: 6_
+
+## Phase 6: Testing and verification
+
+- [ ] 15. Run playbook with --check mode against live cmd-center1
+  - `ansible-playbook site.yml --limit cmd-center1 --check --diff`
+  - Expected: zero changes reported
+  - Fix any idempotency bugs found
+  - _Requirements: 2_
+
+- [ ] 16. Run full playbook against live cmd-center1
+  - `ansible-playbook site.yml --limit cmd-center1 --ask-vault-pass`
+  - Verify spec-workflow dashboard still reachable after run
+  - Verify no pods in `media` namespace restarted (should not touch k8s state)
+  - Verify memory symlinks intact and writable
+  - _Requirements: 1, 2, 4_
+
+- [ ] 17. DR rehearsal: provision a fresh VM
+  - Create a fresh Ubuntu 24.04 VM on PVE
+  - Perform manual prereqs (user creation, SSH access, vault password)
+  - Run playbook against it
+  - Measure time from start to fully working state (target: under 30 min)
+  - Verify all tools present, dashboard reachable, memory symlinks created
+  - Document any gaps found
+  - _Requirements: 1, 5, 6_
+
+- [ ] 18. Add optional verification task
+  - File: `roles/cmd_center/tasks/verify.yml`
+  - Tagged: `tags: [verify, never]` so it only runs when explicitly requested
+  - Assertions for: dashboard HTTP 200, kubectl connectivity, memory symlinks, required tools on PATH
+  - _Requirements: 1_
+
+## Phase 7: Cleanup and PR
+
+- [ ] 19. Create feature branch and open PR
+  - Branch: `feat/cmd-center-dr-provisioning`
+  - Commit messages per existing conventional commits style
+  - PR body links to this spec
+  - _Requirements: (all)_
+
+- [ ] 20. Update project documentation
+  - Main README: link to the cmd_center role README
+  - Update `docs/` if there is a DR runbook page
+  - _Requirements: 6_


### PR DESCRIPTION
## Summary
- Adds a spec-workflow spec documenting the plan to extend the existing `cmd_center` Ansible role to cover all currently-manual provisioning steps
- Goal: fresh Ubuntu 24.04 to fully working command center via single playbook run, RTO under 30 min
- No code changes yet; this is the design artifact for review before implementation

## Spec contents
- `requirements.md`: 6 requirements with acceptance criteria (automation, idempotency, secrets, memory persistence, auto-start, documentation)
- `design.md`: 6 key architectural decisions (extend vs new role, standalone Node 22, user systemd vs system, 1P vault bootstrap, SSH over HTTPS, clone order)
- `tasks.md`: 20 tasks across 7 phases (refactor, dependencies, application layer, orchestration, secrets, testing, cleanup)

## Context
- Recreated from closed PR #108 after a rebase onto main resolved .gitignore conflict
- Ties into recent work on `claude-config` memory symlinks and spec-workflow dashboard setup on command-center1

## Follow-up
- After approval, implement in phases per tasks.md
- Each phase can be its own PR to keep reviews small

## Test plan
- [ ] Review spec for completeness
- [ ] Confirm no blockers on 1P bootstrap token approach
- [ ] Approve or request design changes before implementation begins