### PR TITLE
fix(op-quota-collector): minimize handler cascade

### DIFF
--- a/roles/op_quota_collector/handlers/main.yml
+++ b/roles/op_quota_collector/handlers/main.yml
@@ -1,5 +1,20 @@
 ---
-- name: Reload systemd
+# Handler chain for op_quota_collector:
+#
+#   reload-systemd                  systemctl daemon-reload
+#   restart-op-quota-collector-timer  systemctl restart op-quota-collector.timer
+#
+# Notification policy:
+#   - Code file changes (parse.py, op-killswitch.sh, collector script) do
+#     NOT notify anything. The collector is a oneshot service triggered
+#     by the timer; the next scheduled fire picks up new code automatically.
+#   - Service unit changes notify reload-systemd only. The service is not
+#     long-running; restarting it has no effect outside of a timer fire.
+#   - Timer unit changes notify both reload-systemd and restart-timer so
+#     the new schedule takes effect immediately instead of after the next
+#     fire at the old cadence.
+
+- name: Reload systemd daemon
   ansible.builtin.systemd:
     daemon_reload: true
   listen: reload-systemd
@@ -8,4 +23,4 @@
   ansible.builtin.systemd:
     name: op-quota-collector.timer
     state: restarted
-  listen: restart-op-quota-collector
+  listen: restart-op-quota-collector-timer

--- a/roles/op_quota_collector/tasks/main.yml
+++ b/roles/op_quota_collector/tasks/main.yml
@@ -9,6 +9,9 @@
     group: root
     mode: '0755'
 
+# Code file changes do not notify handlers. The collector is a oneshot
+# service triggered by the timer; the next scheduled fire picks up new
+# code automatically. See handlers/main.yml for policy rationale.
 - name: Install parse.py helper
   ansible.builtin.copy:
     src: parse.py
@@ -16,8 +19,6 @@
     owner: root
     group: root
     mode: '0755'
-  notify:
-    - restart-op-quota-collector
 
 - name: Install shared op-killswitch.sh library
   ansible.builtin.copy:
@@ -26,8 +27,6 @@
     owner: root
     group: root
     mode: '0755'
-  notify:
-    - restart-op-quota-collector
 
 - name: Install collector script
   ansible.builtin.template:
@@ -36,8 +35,6 @@
     owner: root
     group: root
     mode: '0755'
-  notify:
-    - restart-op-quota-collector
 
 - name: Install systemd service unit
   ansible.builtin.template:
@@ -48,7 +45,6 @@
     mode: '0644'
   notify:
     - reload-systemd
-    - restart-op-quota-collector
 
 - name: Install systemd timer unit
   ansible.builtin.template:
@@ -59,7 +55,7 @@
     mode: '0644'
   notify:
     - reload-systemd
-    - restart-op-quota-collector
+    - restart-op-quota-collector-timer
 
 - name: Flush handlers so timer is reloaded before we enable it
   ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
## Summary
- Removed no-op handler notifications from code file changes
- Renamed listen topic for clarity: `restart-op-quota-collector` to `restart-op-quota-collector-timer`
- Added documentation at the top of `handlers/main.yml` explaining the policy

## Why
The collector is a oneshot service triggered by a systemd timer. Restarting the timer on code file changes was a no-op: it just reschedules, it does not run the code immediately. The next timer fire already picks up new files. The previous notifications were misleading.

## Remaining notifications (all meaningful)
- Service unit changes: `reload-systemd` only
- Timer unit changes: `reload-systemd` plus `restart-op-quota-collector-timer` so schedule changes take effect immediately

## Test plan
- [x] YAML syntax valid
- [ ] `ansible-playbook --check --tags op_quota_collector` reports no unexpected changes
- [ ] First real playbook run verifies the rename does not leave dangling notifies

Closes #112