### PR TITLE
refactor(cmd_center): split tasks/main.yml into topical files (Phase 1)

### DIFF
--- a/roles/cmd_center/tasks/ansible_timers.yml
+++ b/roles/cmd_center/tasks/ansible_timers.yml
@@ -1,0 +1,97 @@
+---
+# Deploy the two systemd timer/service pairs that run periodic Ansible
+# playbooks on the command center:
+#
+#   ansible-proxmox  runs run-proxmox.sh against the pve group
+#   ansible-security runs run-security.sh against the whole inventory
+#
+# Both units are system-scoped (not user) because they run playbooks
+# that require root access across the fleet.
+
+- name: Deploy ansible-proxmox systemd service
+  ansible.builtin.template:
+    src: ansible-proxmox.service.j2
+    dest: /etc/systemd/system/ansible-proxmox.service
+    owner: root
+    group: root
+    mode: '0644'
+  notify:
+    - Reload systemd
+    - Restart ansible-proxmox timer
+  tags:
+    - ansible_timers
+
+- name: Deploy ansible-proxmox systemd timer
+  ansible.builtin.template:
+    src: ansible-proxmox.timer.j2
+    dest: /etc/systemd/system/ansible-proxmox.timer
+    owner: root
+    group: root
+    mode: '0644'
+  notify:
+    - Reload systemd
+    - Restart ansible-proxmox timer
+  tags:
+    - ansible_timers
+
+- name: Enable and start ansible-proxmox timer
+  ansible.builtin.systemd:
+    name: ansible-proxmox.timer
+    enabled: true
+    state: started
+  tags:
+    - ansible_timers
+
+- name: Deploy ansible-security systemd service
+  ansible.builtin.template:
+    src: ansible-security.service.j2
+    dest: /etc/systemd/system/ansible-security.service
+    owner: root
+    group: root
+    mode: '0644'
+  notify:
+    - Reload systemd
+    - Restart ansible-security timer
+  tags:
+    - ansible_timers
+
+- name: Deploy ansible-security systemd timer
+  ansible.builtin.template:
+    src: ansible-security.timer.j2
+    dest: /etc/systemd/system/ansible-security.timer
+    owner: root
+    group: root
+    mode: '0644'
+  notify:
+    - Reload systemd
+    - Restart ansible-security timer
+  tags:
+    - ansible_timers
+
+- name: Enable and start ansible-security timer
+  ansible.builtin.systemd:
+    name: ansible-security.timer
+    enabled: true
+    state: started
+  tags:
+    - ansible_timers
+
+- name: Create inventory cache directory
+  ansible.builtin.file:
+    path: /var/lib/ansible-quasarlab
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: '0755'
+  tags:
+    - ansible_timers
+
+- name: Make run scripts executable
+  ansible.builtin.file:
+    path: "{{ ansible_repo_path }}/scripts/{{ item }}"
+    mode: '0755'
+  loop:
+    - run-proxmox.sh
+    - run-security.sh
+  tags:
+    - ansible_timers

--- a/roles/cmd_center/tasks/kubeconfig.yml
+++ b/roles/cmd_center/tasks/kubeconfig.yml
@@ -1,0 +1,47 @@
+---
+# Fetches the admin kubeconfig from the first K8s control plane node
+# and installs it on the command center for the ansible_user. Uses
+# delegate_to+run_once so the fetch happens once even when the role
+# targets multiple command center hosts.
+#
+# Requires: groups['k8s'] populated, passwordless sudo on the control
+# plane node (for reading /etc/kubernetes/admin.conf).
+
+- name: Ensure .kube directory exists
+  ansible.builtin.file:
+    path: /home/{{ ansible_user }}/.kube
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: '0700'
+  tags:
+    - kubeconfig
+
+- name: Wait for kubeconfig to exist on first control plane node
+  ansible.builtin.wait_for:
+    path: /etc/kubernetes/admin.conf
+    timeout: 60
+  delegate_to: "{{ groups['k8s'][0] }}"
+  run_once: true
+  tags:
+    - kubeconfig
+
+- name: Fetch kubeconfig from first control plane node
+  ansible.builtin.fetch:
+    src: /etc/kubernetes/admin.conf
+    dest: /tmp/admin.conf
+    flat: true
+  delegate_to: "{{ groups['k8s'][0] }}"
+  run_once: true
+  tags:
+    - kubeconfig
+
+- name: Copy kubeconfig to command center
+  ansible.builtin.copy:
+    src: /tmp/admin.conf
+    dest: /home/{{ ansible_user }}/.kube/config
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: '0600'
+  tags:
+    - kubeconfig

--- a/roles/cmd_center/tasks/main.yml
+++ b/roles/cmd_center/tasks/main.yml
@@ -1,119 +1,23 @@
-- name: Ensure kubernetes.core collection is installed
-  ansible.builtin.command: ansible-galaxy collection install kubernetes.core --force
-  args:
-    creates: /root/.ansible/collections/ansible_collections/kubernetes/core
-  become: true
+---
+# Orchestrator for the cmd_center role. Task files are included in the
+# order below; each file is standalone and can be run selectively with
+# its matching tag (see the `tags:` key in each file).
+#
+# Planned future task files (per spec cmd-center-dr-provisioning):
+#   cli_tools.yml           helm, yq, gh, terraform
+#   onepassword_token.yml   1P service account token from vault
+#   ssh_keys.yml            SSH keys from 1P via op
+#   linger.yml              loginctl enable-linger for user services
+#   git_repos.yml           clone claude-config and lab repos
+#   claude_bootstrap.yml    run claude-config/bin/bootstrap.sh
+#   node_runtime.yml        standalone Node 22 install
+#   spec_workflow.yml       systemd user unit for dashboard
 
-- name: Install Python packages via apt
-  apt:
-    name:
-      - curl
-      - python3-pip
-      - python3-kubernetes
-      - python3-openshift
-      - python3-yaml
-    state: present
-    update_cache: true
+- name: System packages and Ansible collections
+  ansible.builtin.import_tasks: packages.yml
 
-- name: Ensure .kube directory exists
-  file:
-    path: /home/{{ ansible_user }}/.kube
-    state: directory
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-    mode: '0700'
+- name: Kubeconfig fetch and install
+  ansible.builtin.import_tasks: kubeconfig.yml
 
-- name: Wait for kubeconfig to exist on first control plane node
-  wait_for:
-    path: /etc/kubernetes/admin.conf
-    timeout: 60
-  delegate_to: "{{ groups['k8s'][0] }}"
-  run_once: true
-
-- name: Fetch kubeconfig from first control plane node
-  fetch:
-    src: /etc/kubernetes/admin.conf
-    dest: /tmp/admin.conf
-    flat: true
-  delegate_to: "{{ groups['k8s'][0] }}"
-  run_once: true
-
-- name: Copy kubeconfig to command center
-  copy:
-    src: /tmp/admin.conf
-    dest: /home/{{ ansible_user }}/.kube/config
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-    mode: '0600'
-
-- name: Deploy ansible-proxmox systemd service
-  ansible.builtin.template:
-    src: ansible-proxmox.service.j2
-    dest: /etc/systemd/system/ansible-proxmox.service
-    owner: root
-    group: root
-    mode: '0644'
-  notify:
-    - Reload systemd
-    - Restart ansible-proxmox timer
-
-- name: Deploy ansible-proxmox systemd timer
-  ansible.builtin.template:
-    src: ansible-proxmox.timer.j2
-    dest: /etc/systemd/system/ansible-proxmox.timer
-    owner: root
-    group: root
-    mode: '0644'
-  notify:
-    - Reload systemd
-    - Restart ansible-proxmox timer
-
-- name: Enable and start ansible-proxmox timer
-  ansible.builtin.systemd:
-    name: ansible-proxmox.timer
-    enabled: true
-    state: started
-
-- name: Deploy ansible-security systemd service
-  ansible.builtin.template:
-    src: ansible-security.service.j2
-    dest: /etc/systemd/system/ansible-security.service
-    owner: root
-    group: root
-    mode: '0644'
-  notify:
-    - Reload systemd
-    - Restart ansible-security timer
-
-- name: Deploy ansible-security systemd timer
-  ansible.builtin.template:
-    src: ansible-security.timer.j2
-    dest: /etc/systemd/system/ansible-security.timer
-    owner: root
-    group: root
-    mode: '0644'
-  notify:
-    - Reload systemd
-    - Restart ansible-security timer
-
-- name: Enable and start ansible-security timer
-  ansible.builtin.systemd:
-    name: ansible-security.timer
-    enabled: true
-    state: started
-
-- name: Create inventory cache directory
-  ansible.builtin.file:
-    path: /var/lib/ansible-quasarlab
-    state: directory
-    owner: "{{ ansible_user }}"
-    group: "{{ ansible_user }}"
-    mode: '0755'
-
-- name: Make run scripts executable
-  ansible.builtin.file:
-    path: "{{ ansible_repo_path }}/scripts/{{ item }}"
-    mode: '0755'
-  loop:
-    - run-proxmox.sh
-    - run-security.sh
+- name: Periodic Ansible playbook systemd timers
+  ansible.builtin.import_tasks: ansible_timers.yml

--- a/roles/cmd_center/tasks/packages.yml
+++ b/roles/cmd_center/tasks/packages.yml
@@ -1,0 +1,26 @@
+---
+# System-level dependencies for running kubernetes.core Ansible modules
+# and the python clients they rely on. Kept as apt packages (not pip in
+# a venv) because this host runs the Ansible controller role, not an
+# isolated Python app.
+
+- name: Ensure kubernetes.core collection is installed
+  ansible.builtin.command: ansible-galaxy collection install kubernetes.core --force
+  args:
+    creates: /root/.ansible/collections/ansible_collections/kubernetes/core
+  become: true
+  tags:
+    - packages
+
+- name: Install Python packages via apt
+  ansible.builtin.apt:
+    name:
+      - curl
+      - python3-pip
+      - python3-kubernetes
+      - python3-openshift
+      - python3-yaml
+    state: present
+    update_cache: true
+  tags:
+    - packages


### PR DESCRIPTION
## Summary
Phase 1 of the `cmd-center-dr-provisioning` spec. Splits the existing `roles/cmd_center/tasks/main.yml` into three topical task files imported from `main.yml`.

## Pure refactor
- No behavior change
- All 14 original tasks preserved, order unchanged
- Handlers and variables unchanged
- Each task file carries a matching tag (packages, kubeconfig, ansible_timers) for selective runs

## New structure
```
roles/cmd_center/tasks/
  main.yml            orchestrator, import_tasks in order
  packages.yml        system deps and kubernetes.core collection
  kubeconfig.yml      .kube dir, wait/fetch/copy kubeconfig from CP
  ansible_timers.yml  ansible-proxmox/security service+timer units
```

Subsequent phases per the spec will add: `cli_tools.yml`, `onepassword_token.yml`, `ssh_keys.yml`, `linger.yml`, `git_repos.yml`, `claude_bootstrap.yml`, `node_runtime.yml`, `spec_workflow.yml`.

## Test plan
- [x] YAML valid in all 4 files
- [x] Task count matches original (14 tasks)
- [x] `ansible-playbook --syntax-check` passes
- [ ] `ansible-playbook --check --limit cmd_center playbooks/cmd_center.yml` reports no changes (to run post-merge)

Refs the `cmd-center-dr-provisioning` spec (tasks.md Phase 1, task #1)