### PR TITLE
fix(op_ratelimit_collector): tighten schedule 15m -> 5m

### DIFF
--- a/roles/op_ratelimit_collector/defaults/main.yml
+++ b/roles/op_ratelimit_collector/defaults/main.yml
@@ -3,9 +3,12 @@
 # node_exporter textfile directory (ladino on command-center1).
 op_quota_user: ladino
 
-# Collector cadence. Every 15 min = 96 runs/day = 9.6% of the 1P Families
-# 1000/day account-wide cap. Tune via host_vars if needed.
-op_quota_schedule: "*:0/15"
+# Collector cadence. `op service-account ratelimit` is a control-plane
+# call that does NOT count against any rate-limit tier (verified
+# 2026-04-19 against a draining cap), so frequency is not bounded by
+# quota cost. 5 min gives ~3x better alert resolution than the original
+# 15 min without any downside. Tune via host_vars if needed.
+op_quota_schedule: "*:0/5"
 
 # Output path (must be inside the node_exporter textfile directory).
 op_quota_metric_file: /var/lib/node_exporter/textfiles/op_quota.prom


### PR DESCRIPTION
## Summary

Drops \`op_quota_schedule\` default from \`*:0/15\` to \`*:0/5\` in the collector role defaults.

## Context

Verified on 2026-04-19 that \`op service-account ratelimit\` is a control-plane call that does NOT count against any rate-limit tier. Multiple probes against a draining cap kept the USED counter flat.

Original 15 min cadence was sized to keep collector overhead under 10% of the 1P Families 1000/day cap. Since the call is free, that constraint no longer applies. 5 min gives ~3x better alert resolution so the 10m/15m \`for:\` clauses on the PrometheusRules settle on real trend rather than a single sample.

## Related

- Collector role: #109 (merged)
- Role rename shim: #116 (merged)
- K8s-side alerts and runbook (updated with the same finding): mithr4ndir/k8s-argocd#140

## Test plan

- [ ] After merge + \`cmd_center.yml\` play, \`systemctl list-timers op-ratelimit-collector.timer\` shows NEXT firing within 5 min
- [ ] Metric scrape \`onepassword_ratelimit_collector_timestamp_seconds\` advances within ~5 min between scrapes
- [ ] No USED counter movement in the 1P dashboard attributable to the new cadence