### PR TITLE
feat(cmd_center): add cli_tools task for helm, yq, gh, terraform

### DIFF
--- a/.spec-workflow/specs/cmd-center-dr-provisioning/tasks.md
+++ b/.spec-workflow/specs/cmd-center-dr-provisioning/tasks.md
@@ -12,12 +12,15 @@
 
 ## Phase 2: New task files (dependencies first)
 
-- [ ] 2. Add CLI tools installation
+- [x] 2. Add CLI tools installation
   - File: `roles/cmd_center/tasks/cli_tools.yml`
-  - Install via apt where available: `jq`, `gh` (via hashicorp GPG key + repo), `yq` (binary from GitHub releases if not in apt)
-  - Install `helm` via helm.sh script or binary tarball
-  - Install `terraform` via hashicorp apt repo
-  - Verify `op` is handled by the existing `onepassword_cli` role (include it as a role dependency if needed)
+  - jq installed via apt
+  - gh via official cli.github.com apt repo (keyring in /etc/apt/keyrings)
+  - terraform via hashicorp apt repo (keyring in /etc/apt/keyrings)
+  - helm as pinned versioned binary in /usr/local/bin with a `helm` symlink
+  - yq as pinned versioned binary in /usr/local/bin with a `yq` symlink
+  - `op` is not installed here; the existing `onepassword_cli` role in the playbook handles it
+  - Final verify step runs each tool's `--version` to confirm it is on PATH
   - _Requirements: 1_
 
 - [ ] 3. Add 1Password service account token deployment

--- a/roles/cmd_center/defaults/main.yml
+++ b/roles/cmd_center/defaults/main.yml
@@ -1,6 +1,15 @@
 ---
 ansible_repo_path: /home/{{ ansible_user }}/code/ansible-quasarlab
 
+# Architecture for binary downloads. Used by helm, yq, and apt repo
+# entries. Override for ARM hosts if ever needed.
+dpkg_arch: amd64
+helm_arch: amd64
+
+# CLI tool versions. Pinned so upgrades are intentional.
+helm_version: "3.19.0"
+yq_version: "4.47.2"
+
 # Node.js runtime (standalone install for user-scoped tools like the
 # spec-workflow dashboard, isolated from system apt Node).
 node_version: "22.16.0"

--- a/roles/cmd_center/tasks/cli_tools.yml
+++ b/roles/cmd_center/tasks/cli_tools.yml
@@ -1,0 +1,155 @@
+---
+# Install CLI tools needed for day-to-day homelab ops:
+#   jq, yq   YAML/JSON processing (helm + kustomize rendering)
+#   gh       GitHub CLI (PRs, issues, auth for git push)
+#   helm     Helm client for chart rendering
+#   terraform HashiCorp Terraform for IaC
+#
+# The `op` 1Password CLI is handled by the separate onepassword_cli role.
+#
+# Tools that have official apt repos (gh, terraform) are installed via
+# apt so they track upstream. yq and helm ship as single binaries with
+# no apt repo, so they are downloaded to /usr/local/bin at a pinned
+# version.
+
+- name: Ensure apt keyrings directory exists
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+  become: true
+  tags:
+    - cli_tools
+
+- name: Install jq
+  ansible.builtin.apt:
+    name: jq
+    state: present
+  become: true
+  tags:
+    - cli_tools
+
+# GitHub CLI (gh): official apt repo at cli.github.com
+- name: Download GitHub CLI apt signing key
+  ansible.builtin.get_url:
+    url: https://cli.github.com/packages/githubcli-archive-keyring.gpg
+    dest: /etc/apt/keyrings/githubcli-archive-keyring.gpg
+    mode: '0644'
+  become: true
+  tags:
+    - cli_tools
+
+- name: Add GitHub CLI apt repository
+  ansible.builtin.apt_repository:
+    repo: "deb [arch={{ dpkg_arch }} signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main"
+    filename: github-cli
+    state: present
+  become: true
+  tags:
+    - cli_tools
+
+- name: Install gh
+  ansible.builtin.apt:
+    name: gh
+    state: present
+    update_cache: true
+  become: true
+  tags:
+    - cli_tools
+
+# HashiCorp Terraform: official apt repo at apt.releases.hashicorp.com
+- name: Download HashiCorp apt signing key
+  ansible.builtin.get_url:
+    url: https://apt.releases.hashicorp.com/gpg
+    dest: /etc/apt/keyrings/hashicorp-archive-keyring.gpg
+    mode: '0644'
+  become: true
+  tags:
+    - cli_tools
+
+- name: Add HashiCorp apt repository
+  ansible.builtin.apt_repository:
+    repo: "deb [arch={{ dpkg_arch }} signed-by=/etc/apt/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com {{ ansible_distribution_release }} main"
+    filename: hashicorp
+    state: present
+  become: true
+  tags:
+    - cli_tools
+
+- name: Install terraform
+  ansible.builtin.apt:
+    name: terraform
+    state: present
+    update_cache: true
+  become: true
+  tags:
+    - cli_tools
+
+# Helm: single binary, no apt repo. Pinned version via defaults.
+- name: Install helm binary
+  ansible.builtin.unarchive:
+    src: "https://get.helm.sh/helm-v{{ helm_version }}-linux-{{ helm_arch }}.tar.gz"
+    dest: /tmp
+    remote_src: true
+    creates: "/usr/local/bin/helm-v{{ helm_version }}"
+  become: true
+  tags:
+    - cli_tools
+
+- name: Move helm to /usr/local/bin with versioned name
+  ansible.builtin.copy:
+    src: "/tmp/linux-{{ helm_arch }}/helm"
+    dest: "/usr/local/bin/helm-v{{ helm_version }}"
+    remote_src: true
+    owner: root
+    group: root
+    mode: '0755'
+  become: true
+  tags:
+    - cli_tools
+
+- name: Symlink helm version to /usr/local/bin/helm
+  ansible.builtin.file:
+    src: "/usr/local/bin/helm-v{{ helm_version }}"
+    dest: /usr/local/bin/helm
+    state: link
+    force: true
+  become: true
+  tags:
+    - cli_tools
+
+# yq: single binary from GitHub releases. Pinned version via defaults.
+- name: Install yq binary
+  ansible.builtin.get_url:
+    url: "https://github.com/mikefarah/yq/releases/download/v{{ yq_version }}/yq_linux_{{ helm_arch }}"
+    dest: "/usr/local/bin/yq-v{{ yq_version }}"
+    owner: root
+    group: root
+    mode: '0755'
+  become: true
+  tags:
+    - cli_tools
+
+- name: Symlink yq version to /usr/local/bin/yq
+  ansible.builtin.file:
+    src: "/usr/local/bin/yq-v{{ yq_version }}"
+    dest: /usr/local/bin/yq
+    state: link
+    force: true
+  become: true
+  tags:
+    - cli_tools
+
+- name: Verify CLI tools are on PATH with expected versions
+  ansible.builtin.command: "{{ item }}"
+  loop:
+    - gh --version
+    - terraform version
+    - helm version --short
+    - yq --version
+    - jq --version
+  register: cmd_center_cli_tools_check
+  changed_when: false
+  failed_when: cmd_center_cli_tools_check.rc != 0
+  tags:
+    - cli_tools

--- a/roles/cmd_center/tasks/main.yml
+++ b/roles/cmd_center/tasks/main.yml
@@ -4,7 +4,6 @@
 # its matching tag (see the `tags:` key in each file).
 #
 # Planned future task files (per spec cmd-center-dr-provisioning):
-#   cli_tools.yml           helm, yq, gh, terraform
 #   onepassword_token.yml   1P service account token from vault
 #   ssh_keys.yml            SSH keys from 1P via op
 #   git_repos.yml           clone claude-config and lab repos
@@ -12,6 +11,9 @@
 
 - name: System packages and Ansible collections
   ansible.builtin.import_tasks: packages.yml
+
+- name: CLI tools (gh, terraform, helm, yq, jq)
+  ansible.builtin.import_tasks: cli_tools.yml
 
 - name: Kubeconfig fetch and install
   ansible.builtin.import_tasks: kubeconfig.yml


### PR DESCRIPTION
## Summary
Phase 2 task 2 of the `cmd-center-dr-provisioning` spec. Adds a `cli_tools.yml` task that installs the day-to-day ops CLI tools.

## Installs
| Tool | Source |
|------|--------|
| jq | apt |
| gh | official cli.github.com apt repo with keyring in /etc/apt/keyrings |
| terraform | apt.releases.hashicorp.com with keyring in /etc/apt/keyrings |
| helm | pinned versioned binary at /usr/local/bin/helm-v{{ helm_version }} with a `helm` symlink |
| yq | pinned versioned binary at /usr/local/bin/yq-v{{ yq_version }} with a `yq` symlink |

`op` (1Password CLI) is not installed here; the existing `onepassword_cli` role in the playbook handles it.

## Defaults added
- `dpkg_arch`, `helm_arch` (amd64 default, override for ARM)
- `helm_version` pinned at 3.19.0
- `yq_version` pinned at 4.47.2

## Orchestration
`main.yml` calls `cli_tools.yml` right after `packages.yml`, so the apt cache is warm for the new repos.

## Idempotency
- apt modules: native idempotency
- helm binary: `creates:` on the unarchive step plus a stable versioned path
- yq binary: `get_url` module compares file content and only overwrites on change
- Symlinks: `force: true` keeps the latest version pointed at

## Test plan
- [x] YAML valid
- [x] `ansible-playbook --syntax-check` passes
- [ ] `--check` mode against live cmd-center1 reports no drift (tools already installed by hand)
- [ ] Fresh VM run installs everything cleanly

Refs cmd-center-dr-provisioning spec task 2