### PR TITLE
feat(cmd_center): git_repos, claude_bootstrap, and role README (Phase 3/5)

### DIFF
--- a/.spec-workflow/specs/cmd-center-dr-provisioning/tasks.md
+++ b/.spec-workflow/specs/cmd-center-dr-provisioning/tasks.md
@@ -47,20 +47,18 @@
 
 ## Phase 3: New task files (application layer)
 
-- [ ] 6. Add git repo cloning
+- [x] 6. Add git repo cloning
   - File: `roles/cmd_center/tasks/git_repos.yml`
-  - Loop over `lab_repos` variable
-  - Clone `claude-config` FIRST, then others (order-sensitive due to claude-config bootstrap)
-  - Use `git: update=no` to avoid clobbering local work on re-runs
+  - Loops over `lab_repos`; claude-config cloned first as a distinct task, then the rest
+  - `update: false` protects local commits
   - Target directory: `/home/{{ ansible_user }}/code/{{ item.name }}`
   - _Requirements: 1, 2_
 
-- [ ] 7. Add Claude config bootstrap
+- [x] 7. Add Claude config bootstrap
   - File: `roles/cmd_center/tasks/claude_bootstrap.yml`
-  - Run `~/code/claude-config/bin/bootstrap.sh`
-  - The script is idempotent: it checks for existing symlinks before creating
-  - Verify: `~/.claude/memory` is a symlink to `~/code/claude-config/memory`
-  - Verify: `~/.claude/projects/-home-ladino/memory` is a symlink to `~/code/claude-config/memory`
+  - Runs `~/code/claude-config/bin/bootstrap.sh`
+  - Asserts both `~/.claude/memory` and `~/.claude/projects/-home-{user}/memory` are symlinks pointing at `~/code/claude-config/memory`
+  - Fails fast with a clear message if claude-config was not cloned first
   - _Requirements: 4_
 
 - [x] 8. Add Node 22 standalone install
@@ -104,10 +102,10 @@
   - Document vault password retrieval in README
   - _Requirements: 3_
 
-- [ ] 14. Document manual prereqs
-  - File: `roles/cmd_center/README.md` (create if missing) or update main project README
-  - List: Ubuntu 24.04 fresh install, `ladino` user with sudo, initial SSH key for Ansible runner, ansible-vault password
-  - Reference 1P item paths for SSH keys, op service account token
+- [x] 14. Document manual prereqs
+  - File: `roles/cmd_center/README.md` (new file)
+  - Lists Ubuntu 24.04, `ladino` with sudo, SSH access for runner, ansible-vault password, 1P service account token as prereqs
+  - Documents every task file's tag, the full install inventory, vault variables, and a DR runbook with RTO target
   - _Requirements: 6_
 
 ## Phase 6: Testing and verification

--- a/roles/cmd_center/README.md
+++ b/roles/cmd_center/README.md
@@ -1,0 +1,114 @@
+# cmd_center role
+
+Provisions the command center host (the Ansible controller + Kubernetes
+management + spec-workflow dashboard workstation). Applied by
+`playbooks/cmd_center.yml`.
+
+## What this role installs
+
+| Area | Details |
+|------|---------|
+| Apt packages | curl, python3-pip, python3-kubernetes, python3-openshift, python3-yaml |
+| Ansible collections | kubernetes.core |
+| CLI tools | jq (apt), gh (cli.github.com apt repo), terraform (hashicorp apt repo), helm (pinned binary), yq (pinned binary) |
+| Kubeconfig | Fetched from first k8s control plane, installed at `~/.kube/config` |
+| Systemd timers (system) | `ansible-proxmox.timer`, `ansible-security.timer` with their service units |
+| Systemd linger | Enabled for `ansible_user` so user services survive logout |
+| Git repos | All lab repos cloned under `~/code/` |
+| Claude Code | `claude-config/bin/bootstrap.sh` run to set up `~/.claude` symlinks |
+| Node runtime | Standalone Node 22 at `~/.local/lib/nodejs/current/` (isolated from system apt node) |
+| Spec-workflow dashboard | systemd user service on port 5000, bound to 0.0.0.0 for LAN reach |
+
+`op` (1Password CLI) is installed by the separate `onepassword_cli` role,
+which is already listed in `playbooks/cmd_center.yml`.
+
+## Manual prereqs before first run
+
+1. Fresh Ubuntu 24.04 host with network access
+2. User `ladino` with passwordless sudo (adjust `ansible_user` in inventory if using a different account)
+3. SSH key on the Ansible runner that can reach the new host
+4. Ansible vault password (see Vault section below)
+5. 1Password service account token for the Infrastructure vault (consumed by the planned `onepassword_token.yml` task)
+
+## Running
+
+```bash
+ansible-playbook -i inventory.static.ini playbooks/cmd_center.yml --ask-vault-pass
+```
+
+Selective runs with tags:
+
+```bash
+# Only reinstall CLI tools
+ansible-playbook playbooks/cmd_center.yml --tags cli_tools
+
+# Only redeploy the dashboard unit and restart it
+ansible-playbook playbooks/cmd_center.yml --tags spec_workflow
+
+# Only refresh the kubeconfig
+ansible-playbook playbooks/cmd_center.yml --tags kubeconfig
+```
+
+Available tags per task file:
+
+- `packages`
+- `cli_tools`
+- `kubeconfig`
+- `ansible_timers`
+- `linger`
+- `git_repos`
+- `claude_bootstrap`
+- `node`
+- `spec_workflow`
+
+## Idempotency
+
+Every task is designed to be re-runnable without side effects:
+
+- apt modules use their native state tracking
+- Git clones use `update: false` so local commits are never clobbered
+- Binary installs (helm, yq, Node) use pinned versioned paths with `creates:` or `get_url` checksum comparison
+- Symlinks use `force: true` to repoint without leaving duplicates
+- systemd linger uses a stat check on the marker file
+- `claude-config/bin/bootstrap.sh` is idempotent by design (checks for symlinks before writing)
+
+## Vault
+
+Secrets for this role live in `group_vars/cmd_center/vault.yml` (ansible-vault encrypted).
+The vault password file path is set in `ansible.cfg` under `vault_password_file`.
+
+Variables currently expected in the vault (once `onepassword_token.yml` lands):
+
+- `op_service_account_token` read-only token for the Infrastructure vault
+
+## Variables (defaults)
+
+See `defaults/main.yml` for the full list. Key ones to override in inventory:
+
+- `helm_version`, `yq_version`, `node_version` bump when upstream releases a new pinnable version
+- `spec_workflow_bind_address` set to `127.0.0.1` for localhost-only
+- `spec_workflow_cors_enabled` set to `true` and configure allowed origins if exposing beyond LAN
+- `lab_repos` add or remove repos cloned onto the host
+
+## Disaster recovery runbook
+
+Target RTO: under 30 minutes from fresh Ubuntu 24.04 install to fully working
+command center.
+
+1. Fresh Ubuntu 24.04 install, user `ladino` with sudo, SSH accessible
+2. On the Ansible runner: `ansible-playbook -i inventory.static.ini playbooks/cmd_center.yml --ask-vault-pass`
+3. Verify:
+   - `curl http://<host>:5000` returns HTTP 200 (dashboard)
+   - `kubectl get nodes` works (kubeconfig installed)
+   - `ls -la ~/.claude/memory` shows symlink to `~/code/claude-config/memory`
+   - `systemctl list-timers` shows both ansible-proxmox and ansible-security timers
+4. Reboot the host and re-verify item 3 to confirm services auto-start via linger
+
+## Related spec
+
+Full design rationale lives in
+`.spec-workflow/specs/cmd-center-dr-provisioning/`:
+
+- `requirements.md` what the playbook must achieve
+- `design.md` why each architectural decision was made
+- `tasks.md` tracked progress per phase

--- a/roles/cmd_center/defaults/main.yml
+++ b/roles/cmd_center/defaults/main.yml
@@ -15,6 +15,25 @@ yq_version: "4.47.2"
 node_version: "22.16.0"
 node_install_dir: "/home/{{ ansible_user }}/.local/lib/nodejs"
 
+# Homelab git repos cloned onto the command center. claude-config MUST
+# come first; claude_bootstrap.yml depends on it being present before
+# it runs bootstrap.sh. Order for the rest does not matter.
+lab_repos:
+  - name: claude-config
+    url: "git@github.com:mithr4ndir/claude-config.git"
+  - name: ansible-quasarlab
+    url: "git@github.com:mithr4ndir/ansible-quasarlab.git"
+  - name: k8s-argocd
+    url: "git@github.com:mithr4ndir/k8s-argocd.git"
+  - name: observability-quasarlab
+    url: "git@github.com:mithr4ndir/observability-quasarlab.git"
+  - name: terraform-quasarlab
+    url: "git@github.com:mithr4ndir/terraform-quasarlab.git"
+  - name: quasarlab-disaster-recovery
+    url: "git@github.com:mithr4ndir/quasarlab-disaster-recovery.git"
+  - name: truenas-config-backup
+    url: "git@github.com:mithr4ndir/truenas-config-backup.git"
+
 # spec-workflow dashboard systemd user service.
 # Binds to 0.0.0.0 by default so other hosts on the home lab LAN can
 # reach it. CORS disabled because the dashboard's built-in allowlist

--- a/roles/cmd_center/tasks/claude_bootstrap.yml
+++ b/roles/cmd_center/tasks/claude_bootstrap.yml
@@ -1,0 +1,65 @@
+---
+# Run the claude-config repo's bootstrap.sh to install Claude Code
+# settings, memory symlinks, MCP config, agents, and commands.
+#
+# The script is idempotent: it checks for existing symlinks and
+# settings before writing, so this task is safe to re-run.
+#
+# Depends on: git_repos.yml (claude-config must be cloned first).
+
+- name: Check claude-config bootstrap script exists
+  ansible.builtin.stat:
+    path: "/home/{{ ansible_user }}/code/claude-config/bin/bootstrap.sh"
+  register: cmd_center_claude_bootstrap_stat
+  tags:
+    - claude_bootstrap
+
+- name: Fail if claude-config repo was not cloned
+  ansible.builtin.fail:
+    msg: "claude-config/bin/bootstrap.sh is missing. Run git_repos.yml first."
+  when: not cmd_center_claude_bootstrap_stat.stat.exists
+  tags:
+    - claude_bootstrap
+
+- name: Run claude-config bootstrap.sh
+  ansible.builtin.command: /home/{{ ansible_user }}/code/claude-config/bin/bootstrap.sh
+  become: true
+  become_user: "{{ ansible_user }}"
+  register: cmd_center_claude_bootstrap_out
+  changed_when: "'created' in cmd_center_claude_bootstrap_out.stdout | lower or 'updated' in cmd_center_claude_bootstrap_out.stdout | lower"
+  tags:
+    - claude_bootstrap
+
+- name: Verify auto-memory symlink is in place
+  ansible.builtin.stat:
+    path: "/home/{{ ansible_user }}/.claude/projects/-home-{{ ansible_user }}/memory"
+  register: cmd_center_auto_memory_stat
+  tags:
+    - claude_bootstrap
+
+- name: Assert auto-memory points at claude-config/memory
+  ansible.builtin.assert:
+    that:
+      - cmd_center_auto_memory_stat.stat.islnk | default(false)
+      - cmd_center_auto_memory_stat.stat.lnk_target == "/home/" ~ ansible_user ~ "/code/claude-config/memory"
+    fail_msg: "Auto-memory symlink is missing or points somewhere unexpected"
+    success_msg: "Auto-memory symlinked to claude-config/memory as expected"
+  tags:
+    - claude_bootstrap
+
+- name: Verify memory-bank symlink is in place
+  ansible.builtin.stat:
+    path: "/home/{{ ansible_user }}/.claude/memory"
+  register: cmd_center_memory_bank_stat
+  tags:
+    - claude_bootstrap
+
+- name: Assert memory-bank points at claude-config/memory
+  ansible.builtin.assert:
+    that:
+      - cmd_center_memory_bank_stat.stat.islnk | default(false)
+      - cmd_center_memory_bank_stat.stat.lnk_target == "/home/" ~ ansible_user ~ "/code/claude-config/memory"
+    fail_msg: "Memory-bank symlink is missing or points somewhere unexpected"
+    success_msg: "Memory-bank symlinked to claude-config/memory as expected"
+  tags:
+    - claude_bootstrap

--- a/roles/cmd_center/tasks/git_repos.yml
+++ b/roles/cmd_center/tasks/git_repos.yml
@@ -1,0 +1,46 @@
+---
+# Clone the homelab git repos onto the command center. claude-config
+# must come first because its bin/bootstrap.sh (invoked by
+# claude_bootstrap.yml) creates the ~/.claude symlinks that other repos
+# depend on for spec-workflow and memory.
+#
+# Uses `update: false` so that existing local commits are never
+# clobbered by re-runs. Re-cloning an already-present repo is a no-op.
+#
+# Requires SSH keys deployed to ~/.ssh (from ssh_keys.yml) for the
+# git@github.com URLs to authenticate.
+
+- name: Ensure code directory exists
+  ansible.builtin.file:
+    path: "/home/{{ ansible_user }}/code"
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: '0755'
+  tags:
+    - git_repos
+
+- name: Clone claude-config first (needed by claude_bootstrap.yml)
+  ansible.builtin.git:
+    repo: "{{ (lab_repos | selectattr('name', 'equalto', 'claude-config') | list | first).url }}"
+    dest: "/home/{{ ansible_user }}/code/claude-config"
+    update: false
+    accept_hostkey: true
+  become: true
+  become_user: "{{ ansible_user }}"
+  tags:
+    - git_repos
+
+- name: Clone remaining lab repos
+  ansible.builtin.git:
+    repo: "{{ item.url }}"
+    dest: "/home/{{ ansible_user }}/code/{{ item.name }}"
+    update: false
+    accept_hostkey: true
+  become: true
+  become_user: "{{ ansible_user }}"
+  loop: "{{ lab_repos | rejectattr('name', 'equalto', 'claude-config') | list }}"
+  loop_control:
+    label: "{{ item.name }}"
+  tags:
+    - git_repos

--- a/roles/cmd_center/tasks/main.yml
+++ b/roles/cmd_center/tasks/main.yml
@@ -6,8 +6,6 @@
 # Planned future task files (per spec cmd-center-dr-provisioning):
 #   onepassword_token.yml   1P service account token from vault
 #   ssh_keys.yml            SSH keys from 1P via op
-#   git_repos.yml           clone claude-config and lab repos
-#   claude_bootstrap.yml    run claude-config/bin/bootstrap.sh
 
 - name: System packages and Ansible collections
   ansible.builtin.import_tasks: packages.yml
@@ -23,6 +21,12 @@
 
 - name: Enable systemd linger for user services
   ansible.builtin.import_tasks: linger.yml
+
+- name: Clone homelab git repos
+  ansible.builtin.import_tasks: git_repos.yml
+
+- name: Bootstrap claude-config symlinks and settings
+  ansible.builtin.import_tasks: claude_bootstrap.yml
 
 - name: Standalone Node.js runtime for user-scoped tools
   ansible.builtin.import_tasks: node_runtime.yml


### PR DESCRIPTION
## Summary
Three tasks from the `cmd-center-dr-provisioning` spec bundled into one PR because they all contribute to the "host has the code and Claude Code ready to go" layer.

## New task files
- `git_repos.yml` clones all homelab repos into `~/code/`. `claude-config` is cloned in a distinct task before the rest so the ordering with `claude_bootstrap.yml` is explicit. `update: false` protects any local commits on re-runs.
- `claude_bootstrap.yml` runs `~/code/claude-config/bin/bootstrap.sh` and asserts both auto-memory (`~/.claude/projects/-home-{user}/memory`) and memory-bank (`~/.claude/memory`) symlinks point at `~/code/claude-config/memory`. Fails fast with a clear message if claude-config was not cloned first.

## Defaults added
- `lab_repos` list with claude-config first, then ansible-quasarlab, k8s-argocd, observability-quasarlab, terraform-quasarlab, quasarlab-disaster-recovery, truenas-config-backup

## Orchestration
`main.yml` now calls `git_repos.yml` then `claude_bootstrap.yml` right after `linger`, before `node_runtime` and `spec_workflow`.

## README
New `roles/cmd_center/README.md` documents:
- Every task file and its tag
- Manual prereqs before first playbook run
- Vault variables
- DR runbook with RTO target
- Selective run examples

## Remaining spec work
- Task 3 (onepassword_token.yml) secrets layer
- Task 4 (ssh_keys.yml) SSH keys from 1P via op
- Task 13 (vault file) actually encrypt the token
- Tasks 15-18 (testing phases including DR rehearsal on fresh VM)

## Test plan
- [x] YAML valid in all files
- [x] `ansible-playbook --syntax-check` passes
- [ ] `--check` mode on cmd-center1 reports no drift (all repos already cloned, bootstrap already run)
- [ ] Fresh VM run clones repos and bootstraps claude-config correctly once ssh_keys.yml lands

Refs cmd-center-dr-provisioning spec tasks 6, 7, 14