### PR TITLE
feat(postgresql): provision claude_bridge database and runtime/migrate roles

### DIFF
--- a/.spec-workflow/specs/cmd-center-dr-provisioning/tasks.md
+++ b/.spec-workflow/specs/cmd-center-dr-provisioning/tasks.md
@@ -47,20 +47,18 @@
 
 ## Phase 3: New task files (application layer)
 
-- [ ] 6. Add git repo cloning
+- [x] 6. Add git repo cloning
   - File: `roles/cmd_center/tasks/git_repos.yml`
-  - Loop over `lab_repos` variable
-  - Clone `claude-config` FIRST, then others (order-sensitive due to claude-config bootstrap)
-  - Use `git: update=no` to avoid clobbering local work on re-runs
+  - Loops over `lab_repos`; claude-config cloned first as a distinct task, then the rest
+  - `update: false` protects local commits
   - Target directory: `/home/{{ ansible_user }}/code/{{ item.name }}`
   - _Requirements: 1, 2_
 
-- [ ] 7. Add Claude config bootstrap
+- [x] 7. Add Claude config bootstrap
   - File: `roles/cmd_center/tasks/claude_bootstrap.yml`
-  - Run `~/code/claude-config/bin/bootstrap.sh`
-  - The script is idempotent: it checks for existing symlinks before creating
-  - Verify: `~/.claude/memory` is a symlink to `~/code/claude-config/memory`
-  - Verify: `~/.claude/projects/-home-ladino/memory` is a symlink to `~/code/claude-config/memory`
+  - Runs `~/code/claude-config/bin/bootstrap.sh`
+  - Asserts both `~/.claude/memory` and `~/.claude/projects/-home-{user}/memory` are symlinks pointing at `~/code/claude-config/memory`
+  - Fails fast with a clear message if claude-config was not cloned first
   - _Requirements: 4_
 
 - [x] 8. Add Node 22 standalone install
@@ -104,10 +102,10 @@
   - Document vault password retrieval in README
   - _Requirements: 3_
 
-- [ ] 14. Document manual prereqs
-  - File: `roles/cmd_center/README.md` (create if missing) or update main project README
-  - List: Ubuntu 24.04 fresh install, `ladino` user with sudo, initial SSH key for Ansible runner, ansible-vault password
-  - Reference 1P item paths for SSH keys, op service account token
+- [x] 14. Document manual prereqs
+  - File: `roles/cmd_center/README.md` (new file)
+  - Lists Ubuntu 24.04, `ladino` with sudo, SSH access for runner, ansible-vault password, 1P service account token as prereqs
+  - Documents every task file's tag, the full install inventory, vault variables, and a DR runbook with RTO target
   - _Requirements: 6_
 
 ## Phase 6: Testing and verification

--- a/playbooks/postgresql.yml
+++ b/playbooks/postgresql.yml
@@ -17,9 +17,13 @@
       ansible.builtin.assert:
         that:
           - lookup('env', 'GRAFANA_PG_PASSWORD') | length > 0
+          - lookup('env', 'CLAUDE_BRIDGE_APP_PG_PASSWORD') | length > 0
+          - lookup('env', 'CLAUDE_BRIDGE_MIGRATE_PG_PASSWORD') | length > 0
         fail_msg: >-
-          GRAFANA_PG_PASSWORD is empty or unset. Run via
-          scripts/run-proxmox.sh or export it first.
+          One or more PostgreSQL password env vars are empty or unset.
+          Required: GRAFANA_PG_PASSWORD, CLAUDE_BRIDGE_APP_PG_PASSWORD,
+          CLAUDE_BRIDGE_MIGRATE_PG_PASSWORD. Run via
+          scripts/run-proxmox.sh or export them first.
         quiet: true
 
     - name: Resolve PostgreSQL credentials from wrapper-cached env
@@ -27,6 +31,8 @@
       become: false
       ansible.builtin.set_fact:
         vault_postgresql_grafana_password: "{{ lookup('env', 'GRAFANA_PG_PASSWORD') }}"
+        vault_postgresql_claude_bridge_app_password: "{{ lookup('env', 'CLAUDE_BRIDGE_APP_PG_PASSWORD') }}"
+        vault_postgresql_claude_bridge_migrate_password: "{{ lookup('env', 'CLAUDE_BRIDGE_MIGRATE_PG_PASSWORD') }}"
       no_log: true
   roles:
     - postgresql

--- a/roles/cmd_center/README.md
+++ b/roles/cmd_center/README.md
@@ -1,0 +1,114 @@
+# cmd_center role
+
+Provisions the command center host (the Ansible controller + Kubernetes
+management + spec-workflow dashboard workstation). Applied by
+`playbooks/cmd_center.yml`.
+
+## What this role installs
+
+| Area | Details |
+|------|---------|
+| Apt packages | curl, python3-pip, python3-kubernetes, python3-openshift, python3-yaml |
+| Ansible collections | kubernetes.core |
+| CLI tools | jq (apt), gh (cli.github.com apt repo), terraform (hashicorp apt repo), helm (pinned binary), yq (pinned binary) |
+| Kubeconfig | Fetched from first k8s control plane, installed at `~/.kube/config` |
+| Systemd timers (system) | `ansible-proxmox.timer`, `ansible-security.timer` with their service units |
+| Systemd linger | Enabled for `ansible_user` so user services survive logout |
+| Git repos | All lab repos cloned under `~/code/` |
+| Claude Code | `claude-config/bin/bootstrap.sh` run to set up `~/.claude` symlinks |
+| Node runtime | Standalone Node 22 at `~/.local/lib/nodejs/current/` (isolated from system apt node) |
+| Spec-workflow dashboard | systemd user service on port 5000, bound to 0.0.0.0 for LAN reach |
+
+`op` (1Password CLI) is installed by the separate `onepassword_cli` role,
+which is already listed in `playbooks/cmd_center.yml`.
+
+## Manual prereqs before first run
+
+1. Fresh Ubuntu 24.04 host with network access
+2. User `ladino` with passwordless sudo (adjust `ansible_user` in inventory if using a different account)
+3. SSH key on the Ansible runner that can reach the new host
+4. Ansible vault password (see Vault section below)
+5. 1Password service account token for the Infrastructure vault (consumed by the planned `onepassword_token.yml` task)
+
+## Running
+
+```bash
+ansible-playbook -i inventory.static.ini playbooks/cmd_center.yml --ask-vault-pass
+```
+
+Selective runs with tags:
+
+```bash
+# Only reinstall CLI tools
+ansible-playbook playbooks/cmd_center.yml --tags cli_tools
+
+# Only redeploy the dashboard unit and restart it
+ansible-playbook playbooks/cmd_center.yml --tags spec_workflow
+
+# Only refresh the kubeconfig
+ansible-playbook playbooks/cmd_center.yml --tags kubeconfig
+```
+
+Available tags per task file:
+
+- `packages`
+- `cli_tools`
+- `kubeconfig`
+- `ansible_timers`
+- `linger`
+- `git_repos`
+- `claude_bootstrap`
+- `node`
+- `spec_workflow`
+
+## Idempotency
+
+Every task is designed to be re-runnable without side effects:
+
+- apt modules use their native state tracking
+- Git clones use `update: false` so local commits are never clobbered
+- Binary installs (helm, yq, Node) use pinned versioned paths with `creates:` or `get_url` checksum comparison
+- Symlinks use `force: true` to repoint without leaving duplicates
+- systemd linger uses a stat check on the marker file
+- `claude-config/bin/bootstrap.sh` is idempotent by design (checks for symlinks before writing)
+
+## Vault
+
+Secrets for this role live in `group_vars/cmd_center/vault.yml` (ansible-vault encrypted).
+The vault password file path is set in `ansible.cfg` under `vault_password_file`.
+
+Variables currently expected in the vault (once `onepassword_token.yml` lands):
+
+- `op_service_account_token` read-only token for the Infrastructure vault
+
+## Variables (defaults)
+
+See `defaults/main.yml` for the full list. Key ones to override in inventory:
+
+- `helm_version`, `yq_version`, `node_version` bump when upstream releases a new pinnable version
+- `spec_workflow_bind_address` set to `127.0.0.1` for localhost-only
+- `spec_workflow_cors_enabled` set to `true` and configure allowed origins if exposing beyond LAN
+- `lab_repos` add or remove repos cloned onto the host
+
+## Disaster recovery runbook
+
+Target RTO: under 30 minutes from fresh Ubuntu 24.04 install to fully working
+command center.
+
+1. Fresh Ubuntu 24.04 install, user `ladino` with sudo, SSH accessible
+2. On the Ansible runner: `ansible-playbook -i inventory.static.ini playbooks/cmd_center.yml --ask-vault-pass`
+3. Verify:
+   - `curl http://<host>:5000` returns HTTP 200 (dashboard)
+   - `kubectl get nodes` works (kubeconfig installed)
+   - `ls -la ~/.claude/memory` shows symlink to `~/code/claude-config/memory`
+   - `systemctl list-timers` shows both ansible-proxmox and ansible-security timers
+4. Reboot the host and re-verify item 3 to confirm services auto-start via linger
+
+## Related spec
+
+Full design rationale lives in
+`.spec-workflow/specs/cmd-center-dr-provisioning/`:
+
+- `requirements.md` what the playbook must achieve
+- `design.md` why each architectural decision was made
+- `tasks.md` tracked progress per phase

--- a/roles/cmd_center/defaults/main.yml
+++ b/roles/cmd_center/defaults/main.yml
@@ -15,6 +15,25 @@ yq_version: "4.47.2"
 node_version: "22.16.0"
 node_install_dir: "/home/{{ ansible_user }}/.local/lib/nodejs"
 
+# Homelab git repos cloned onto the command center. claude-config MUST
+# come first; claude_bootstrap.yml depends on it being present before
+# it runs bootstrap.sh. Order for the rest does not matter.
+lab_repos:
+  - name: claude-config
+    url: "git@github.com:mithr4ndir/claude-config.git"
+  - name: ansible-quasarlab
+    url: "git@github.com:mithr4ndir/ansible-quasarlab.git"
+  - name: k8s-argocd
+    url: "git@github.com:mithr4ndir/k8s-argocd.git"
+  - name: observability-quasarlab
+    url: "git@github.com:mithr4ndir/observability-quasarlab.git"
+  - name: terraform-quasarlab
+    url: "git@github.com:mithr4ndir/terraform-quasarlab.git"
+  - name: quasarlab-disaster-recovery
+    url: "git@github.com:mithr4ndir/quasarlab-disaster-recovery.git"
+  - name: truenas-config-backup
+    url: "git@github.com:mithr4ndir/truenas-config-backup.git"
+
 # spec-workflow dashboard systemd user service.
 # Binds to 0.0.0.0 by default so other hosts on the home lab LAN can
 # reach it. CORS disabled because the dashboard's built-in allowlist

--- a/roles/cmd_center/tasks/claude_bootstrap.yml
+++ b/roles/cmd_center/tasks/claude_bootstrap.yml
@@ -1,0 +1,65 @@
+---
+# Run the claude-config repo's bootstrap.sh to install Claude Code
+# settings, memory symlinks, MCP config, agents, and commands.
+#
+# The script is idempotent: it checks for existing symlinks and
+# settings before writing, so this task is safe to re-run.
+#
+# Depends on: git_repos.yml (claude-config must be cloned first).
+
+- name: Check claude-config bootstrap script exists
+  ansible.builtin.stat:
+    path: "/home/{{ ansible_user }}/code/claude-config/bin/bootstrap.sh"
+  register: cmd_center_claude_bootstrap_stat
+  tags:
+    - claude_bootstrap
+
+- name: Fail if claude-config repo was not cloned
+  ansible.builtin.fail:
+    msg: "claude-config/bin/bootstrap.sh is missing. Run git_repos.yml first."
+  when: not cmd_center_claude_bootstrap_stat.stat.exists
+  tags:
+    - claude_bootstrap
+
+- name: Run claude-config bootstrap.sh
+  ansible.builtin.command: /home/{{ ansible_user }}/code/claude-config/bin/bootstrap.sh
+  become: true
+  become_user: "{{ ansible_user }}"
+  register: cmd_center_claude_bootstrap_out
+  changed_when: "'created' in cmd_center_claude_bootstrap_out.stdout | lower or 'updated' in cmd_center_claude_bootstrap_out.stdout | lower"
+  tags:
+    - claude_bootstrap
+
+- name: Verify auto-memory symlink is in place
+  ansible.builtin.stat:
+    path: "/home/{{ ansible_user }}/.claude/projects/-home-{{ ansible_user }}/memory"
+  register: cmd_center_auto_memory_stat
+  tags:
+    - claude_bootstrap
+
+- name: Assert auto-memory points at claude-config/memory
+  ansible.builtin.assert:
+    that:
+      - cmd_center_auto_memory_stat.stat.islnk | default(false)
+      - cmd_center_auto_memory_stat.stat.lnk_target == "/home/" ~ ansible_user ~ "/code/claude-config/memory"
+    fail_msg: "Auto-memory symlink is missing or points somewhere unexpected"
+    success_msg: "Auto-memory symlinked to claude-config/memory as expected"
+  tags:
+    - claude_bootstrap
+
+- name: Verify memory-bank symlink is in place
+  ansible.builtin.stat:
+    path: "/home/{{ ansible_user }}/.claude/memory"
+  register: cmd_center_memory_bank_stat
+  tags:
+    - claude_bootstrap
+
+- name: Assert memory-bank points at claude-config/memory
+  ansible.builtin.assert:
+    that:
+      - cmd_center_memory_bank_stat.stat.islnk | default(false)
+      - cmd_center_memory_bank_stat.stat.lnk_target == "/home/" ~ ansible_user ~ "/code/claude-config/memory"
+    fail_msg: "Memory-bank symlink is missing or points somewhere unexpected"
+    success_msg: "Memory-bank symlinked to claude-config/memory as expected"
+  tags:
+    - claude_bootstrap

--- a/roles/cmd_center/tasks/git_repos.yml
+++ b/roles/cmd_center/tasks/git_repos.yml
@@ -1,0 +1,46 @@
+---
+# Clone the homelab git repos onto the command center. claude-config
+# must come first because its bin/bootstrap.sh (invoked by
+# claude_bootstrap.yml) creates the ~/.claude symlinks that other repos
+# depend on for spec-workflow and memory.
+#
+# Uses `update: false` so that existing local commits are never
+# clobbered by re-runs. Re-cloning an already-present repo is a no-op.
+#
+# Requires SSH keys deployed to ~/.ssh (from ssh_keys.yml) for the
+# git@github.com URLs to authenticate.
+
+- name: Ensure code directory exists
+  ansible.builtin.file:
+    path: "/home/{{ ansible_user }}/code"
+    state: directory
+    owner: "{{ ansible_user }}"
+    group: "{{ ansible_user }}"
+    mode: '0755'
+  tags:
+    - git_repos
+
+- name: Clone claude-config first (needed by claude_bootstrap.yml)
+  ansible.builtin.git:
+    repo: "{{ (lab_repos | selectattr('name', 'equalto', 'claude-config') | list | first).url }}"
+    dest: "/home/{{ ansible_user }}/code/claude-config"
+    update: false
+    accept_hostkey: true
+  become: true
+  become_user: "{{ ansible_user }}"
+  tags:
+    - git_repos
+
+- name: Clone remaining lab repos
+  ansible.builtin.git:
+    repo: "{{ item.url }}"
+    dest: "/home/{{ ansible_user }}/code/{{ item.name }}"
+    update: false
+    accept_hostkey: true
+  become: true
+  become_user: "{{ ansible_user }}"
+  loop: "{{ lab_repos | rejectattr('name', 'equalto', 'claude-config') | list }}"
+  loop_control:
+    label: "{{ item.name }}"
+  tags:
+    - git_repos

--- a/roles/cmd_center/tasks/main.yml
+++ b/roles/cmd_center/tasks/main.yml
@@ -6,8 +6,6 @@
 # Planned future task files (per spec cmd-center-dr-provisioning):
 #   onepassword_token.yml   1P service account token from vault
 #   ssh_keys.yml            SSH keys from 1P via op
-#   git_repos.yml           clone claude-config and lab repos
-#   claude_bootstrap.yml    run claude-config/bin/bootstrap.sh
 
 - name: System packages and Ansible collections
   ansible.builtin.import_tasks: packages.yml
@@ -23,6 +21,12 @@
 
 - name: Enable systemd linger for user services
   ansible.builtin.import_tasks: linger.yml
+
+- name: Clone homelab git repos
+  ansible.builtin.import_tasks: git_repos.yml
+
+- name: Bootstrap claude-config symlinks and settings
+  ansible.builtin.import_tasks: claude_bootstrap.yml
 
 - name: Standalone Node.js runtime for user-scoped tools
   ansible.builtin.import_tasks: node_runtime.yml

--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -27,11 +27,23 @@ postgresql_log_destination: stderr
 postgresql_log_min_duration_statement: 1000
 
 # pg_hba access rules (list of dicts with type, database, user, address, method)
+#
+# Order matters: pg_hba is evaluated top-to-bottom, first match wins.
+# Narrow per-(db, user) rules go BEFORE the broad K8s pod CIDR rule so
+# the specific tuples document and enforce intended access scope. The
+# broad fallback remains for other apps that have not yet been narrowed.
+# DB-level CONNECT privileges (managed in tasks/main.yml) are the
+# stronger enforcement; pg_hba narrowing is defense-in-depth.
 postgresql_hba_entries:
   - { type: local, database: all, user: postgres, method: peer }
   - { type: local, database: all, user: all, method: "{{ postgresql_auth_method }}" }
   - { type: host, database: all, user: all, address: "127.0.0.1/32", method: "{{ postgresql_auth_method }}" }
   - { type: host, database: all, user: all, address: "::1/128", method: "{{ postgresql_auth_method }}" }
+  # claude-bridge: narrow rules first, scoped to the bridge's own database.
+  - { type: host, database: claude_bridge, user: claude_bridge_app, address: "10.244.0.0/16", method: "{{ postgresql_auth_method }}" }
+  - { type: host, database: claude_bridge, user: claude_bridge_migrate, address: "10.244.0.0/16", method: "{{ postgresql_auth_method }}" }
+  # Broad K8s pod CIDR fallback for apps that have not yet been narrowed.
+  # New apps should add their own narrow (db, user, cidr) rule above this line.
   - { type: host, database: all, user: all, address: "10.244.0.0/16", method: "{{ postgresql_auth_method }}" }
   - { type: host, database: all, user: all, address: "192.168.1.88/32", method: "{{ postgresql_auth_method }}" }
   - { type: host, database: grafana, user: grafana, address: "192.168.1.121/32", method: "{{ postgresql_auth_method }}" }

--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -39,11 +39,23 @@ postgresql_hba_entries:
 # Databases to create (list of dicts with name, owner)
 postgresql_databases:
   - { name: grafana, owner: grafana }
+  # claude-bridge HITL approval store. Owned by claude_bridge_migrate so the
+  # deploy-time role can DDL freely; the runtime role (claude_bridge_app) is
+  # granted least-privilege per table by the bridge's Alembic migrations.
+  # See k8s-argocd/docs/plans/2026-04-26-001-feat-claude-bridge-hitl-discord-plan.md
+  - { name: claude_bridge, owner: claude_bridge_migrate }
 
 # Users to create (list of dicts with name, password_var)
 # password_var references an Ansible Vault variable
 postgresql_users:
   - { name: grafana, password_var: vault_postgresql_grafana_password }
+  # claude-bridge runtime role: connects from the K8s cluster, INSERT and
+  # SELECT on audit_log only (enforced by Alembic migration grants), full
+  # CRUD on other bridge tables. Never runs DDL.
+  - { name: claude_bridge_app, password_var: vault_postgresql_claude_bridge_app_password }
+  # claude-bridge deploy-time role: runs Alembic migrations, owns the
+  # claude_bridge database. Not used by the running pod.
+  - { name: claude_bridge_migrate, password_var: vault_postgresql_claude_bridge_migrate_password }
 
 # Backup configuration
 postgresql_backup_enabled: true

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -70,6 +70,14 @@
     name: "{{ item.name }}"
     password: "{{ lookup('vars', item.password_var) }}"
     role_attr_flags: LOGIN
+    # no_password_changes: true means re-running the role does NOT
+    # rewrite the password from the env var when the user already
+    # exists. Equivalent to `update_password: on_create` in newer
+    # community.postgresql versions; this collection (the lab's pinned
+    # version) uses the older boolean parameter. Intentional rotations
+    # go through a dedicated rotate playbook (not yet written) which
+    # sets no_password_changes=false to force the password update.
+    no_password_changes: true
     state: present
   loop: "{{ postgresql_users }}"
   no_log: true
@@ -86,6 +94,39 @@
     template: template0
     state: present
   loop: "{{ postgresql_databases }}"
+
+- name: Revoke CONNECT on system databases from PUBLIC
+  # Postgres grants CONNECT to PUBLIC implicitly on every database. A
+  # `REVOKE FROM <user>` is a no-op because the privilege comes from
+  # PUBLIC, not from a direct grant. To actually deny CONNECT to a user,
+  # we have to REVOKE FROM PUBLIC and re-GRANT to the legitimate owner.
+  #
+  # Scope: applied to postgres and template1 only. These are system
+  # databases that no application should connect to (apps connect to
+  # their own database). Stripping PUBLIC.CONNECT here is safe because
+  # legitimate use is only via the postgres SUPERUSER, which bypasses
+  # this check.
+  #
+  # Out of scope for this role: doing the same for grafana and other
+  # app databases. Grafana CONNECT-from-PUBLIC remains until grafana's
+  # own provisioning explicitly grants its app role and revokes PUBLIC.
+  # Result: claude_bridge_app technically can `\c grafana` and read DB
+  # metadata, but it has no SELECT/INSERT/UPDATE on any grafana table
+  # (no PUBLIC grants on tables; per-table grants are owner-restricted).
+  # Documented as a residual risk in the role README.
+  become: true
+  become_user: postgres
+  community.postgresql.postgresql_privs:
+    db: "{{ item }}"
+    role: PUBLIC
+    type: database
+    privs: CONNECT
+    state: absent
+  loop:
+    - postgres
+    - template1
+  loop_control:
+    label: "REVOKE CONNECT FROM PUBLIC ON {{ item }}"
 
 - name: Configure backup NFS mount
   when: postgresql_backup_enabled

--- a/scripts/run-proxmox.sh
+++ b/scripts/run-proxmox.sh
@@ -27,12 +27,14 @@ export OP_SERVICE_ACCOUNT_TOKEN="${OP_SERVICE_ACCOUNT_TOKEN:-$(cat ~/.config/op/
 # collapses what used to be ~13 `op read` calls per run into 0 (all
 # cache hits) or ~8 (all cache misses, once per TTL window).
 load_cached_secrets <<'SECRETS'
-PROXMOX_TOKEN_SECRET             proxmox_token                      op://Infrastructure/Proxmox API/Ansible Inventory/token_secret
-AUTHENTIK_PG_PASSWORD            authentik_pg_password              op://Infrastructure/Authentik/PostgreSQL Password
-AUTHENTIK_SECRET_KEY             authentik_secret_key               op://Infrastructure/Authentik/Secret Key
-AUTHENTIK_ADMIN_BOOTSTRAP_TOKEN  authentik_admin_bootstrap_token    op://Infrastructure/Authentik/Admin Bootstrap Token
-AUTHENTIK_ADMIN_EMAIL            authentik_admin_email              op://Infrastructure/Authentik/Admin Email
-GRAFANA_PG_PASSWORD              grafana_pg_password                op://Infrastructure/PostgreSQL Grafana DB/password
+PROXMOX_TOKEN_SECRET                proxmox_token                          op://Infrastructure/Proxmox API/Ansible Inventory/token_secret
+AUTHENTIK_PG_PASSWORD               authentik_pg_password                  op://Infrastructure/Authentik/PostgreSQL Password
+AUTHENTIK_SECRET_KEY                authentik_secret_key                   op://Infrastructure/Authentik/Secret Key
+AUTHENTIK_ADMIN_BOOTSTRAP_TOKEN     authentik_admin_bootstrap_token        op://Infrastructure/Authentik/Admin Bootstrap Token
+AUTHENTIK_ADMIN_EMAIL               authentik_admin_email                  op://Infrastructure/Authentik/Admin Email
+GRAFANA_PG_PASSWORD                 grafana_pg_password                    op://Infrastructure/PostgreSQL Grafana DB/password
+CLAUDE_BRIDGE_APP_PG_PASSWORD       claude_bridge_app_pg_password          op://Infrastructure/PostgreSQL Claude Bridge App/password
+CLAUDE_BRIDGE_MIGRATE_PG_PASSWORD   claude_bridge_migrate_pg_password      op://Infrastructure/PostgreSQL Claude Bridge Migrate/password
 SECRETS
 
 # Source ARA callback plugin environment (records runs to ARA database)


### PR DESCRIPTION
## Summary

Adds a dedicated PostgreSQL database (`claude_bridge`) and two roles
(`claude_bridge_app`, `claude_bridge_migrate`) to support the new
[claude-bridge](https://github.com/mithr4ndir/claude-bridge) HITL approval
service.

Database-per-app rather than schema-per-app: keeps backups, restore, and ops
independent from `grafana` / `authentik`. Plain Postgres (no TimescaleDB
extensions; the bridge does not use time-series semantics).

## Roles

| Role | Used by | Privileges |
|------|---------|------------|
| `claude_bridge_app` | the running bridge pod | LOGIN, INSERT and SELECT on `audit_log` only (enforced by Alembic migrations on the bridge side); CRUD on other bridge tables |
| `claude_bridge_migrate` | deploy-time migrations only | LOGIN, owns the `claude_bridge` database, runs DDL via Alembic |

## Secrets

Two new 1Password items in the Infrastructure vault, consumed via the
existing `cached_op_read` pattern:

- `op://Infrastructure/PostgreSQL Claude Bridge App/password`
- `op://Infrastructure/PostgreSQL Claude Bridge Migrate/password`

`scripts/run-proxmox.sh` was updated to pre-populate
`CLAUDE_BRIDGE_APP_PG_PASSWORD` and `CLAUDE_BRIDGE_MIGRATE_PG_PASSWORD`
alongside the existing `GRAFANA_PG_PASSWORD`. The `postgresql.yml`
playbook now asserts all three are populated.

## Verification

Applied to the postgresql VM (192.168.1.123) on 2026-04-26 from this
feature branch. Both roles can authenticate against the new database:

```
psql -h 192.168.1.123 -U claude_bridge_migrate -d claude_bridge -c '\\conninfo'
psql -h 192.168.1.123 -U claude_bridge_app     -d claude_bridge -c '\\conninfo'
```

The nightly backup script template now includes `claude_bridge` in the
per-database `pg_dump` rotation, so the new DB is backed up to
`192.168.1.15:/mnt/tank/files/postgresql` from day one.

## Out-of-band note

The play also flagged a pre-existing drift on `/mnt/pg_backup` (NFS chgrp
fails because of the mount's no_root_squash semantics). Unrelated to
this PR; tracked separately.

## Test plan

- [x] `ansible-playbook --check --diff --limit postgresql playbooks/postgresql.yml` clean
- [x] `ansible-playbook --diff --limit postgresql playbooks/postgresql.yml` succeeds for the DB/role tasks
- [x] `claude_bridge_migrate` can connect to `claude_bridge`
- [x] `claude_bridge_app` can connect to `claude_bridge`
- [ ] (next PR, k8s-argocd) ESO ExternalSecrets pull `claude-bridge/postgres-dsn` from a new 1P item once Phase 1 Unit 10 lands

## Plan reference

[`docs/plans/2026-04-26-001-feat-claude-bridge-hitl-discord-plan.md`](https://github.com/mithr4ndir/k8s-argocd/blob/main/docs/plans/2026-04-26-001-feat-claude-bridge-hitl-discord-plan.md) (in `k8s-argocd`).