### PR TITLE
fix(op_ratelimit_collector): bypass killswitch gate for free ratelimit call

### DIFF
--- a/roles/op_ratelimit_collector/templates/op-quota-collector.sh.j2
+++ b/roles/op_ratelimit_collector/templates/op-quota-collector.sh.j2
@@ -59,19 +59,20 @@ finish() {
     exit 0
 }
 
-# Ensure the kill-switch library is present and source it. If it is not
-# available we cannot safely call op, since we cannot detect a rate-limit
-# trip. Bail out as a collector failure rather than risk pinning 1P.
+# Ensure the kill-switch library is present and source it. We do NOT
+# gate the actual op call behind op_killswitch_is_active here because
+# `op service-account ratelimit` is a free control-plane call (verified
+# 2026-04-19, see memory feedback_op_rate_limit_care). Gating it would
+# blind the dashboard during exactly the incidents the collector exists
+# to observe. We still load the lib so op_killswitch_scan_file can trip
+# the lock on the response if a "Too many requests" marker appears,
+# protecting OTHER callers (wrappers, vault-pass) that do make billable
+# calls.
 if [[ -f "$KILLSWITCH_LIB" ]]; then
     # shellcheck source=/dev/null
     source "$KILLSWITCH_LIB"
 else
     finish "killswitch_lib_missing" 0
-fi
-
-# Kill switch already tripped? Skip the op call entirely.
-if op_killswitch_is_active; then
-    finish "killswitch" 0
 fi
 
 # Load the op service account token from the standard location used by


### PR DESCRIPTION
## Summary

The 1P quota collector intentionally exits with `success=0 reason=killswitch` when the rate-limit kill switch is tripped. That gate blinds the Grafana dashboard at exactly the moments the data is most actionable: during a rate-limit incident.

`op service-account ratelimit` is a control-plane call that does not count against any of the three rate-limit tiers. Verified 2026-04-19 against a draining cap (USED counter stayed flat across multiple back-to-back probes) and again on 2026-05-02 with the account `read_write` cap at 1000/1000.

This PR drops the early-exit gate. The kill-switch library is still sourced so `op_killswitch_scan_file` can trip the lock on a "Too many requests" marker in the response, protecting other callers (wrappers, vault-pass) that DO make billable `op` calls.

## Why now

Recurrence on 2026-05-02. Account read_write cap exhausted. Killswitch active since 04:22 UTC. The collector was firing every 5 min and writing only `collector_success=0 reason=killswitch` lines. Dashboard panels for `onepassword_ratelimit_remaining`, `_used`, `_limit`, `_reset_seconds` were empty. After applying this change locally the collector populated all gauges on the next tick.

## Test plan

- [x] `python3 -m unittest discover -v roles/op_ratelimit_collector/tests` passes (5/5)
- [x] Bash syntax check on rendered template (`bash -n` after substituting `{{ }}` placeholders) passes
- [x] Manual run against a live exhausted cap on command-center1 emitted full gauge body within one collector tick
- [ ] Re-apply role to a host where killswitch is currently inactive to confirm no regression in the happy path
- [ ] Verify `op_killswitch_scan_file` still trips the lock when stdout/stderr contains a rate-limit marker (existing logic, unchanged by this PR)

## Related

- Recurrence context: \`memory/project_2026-05-02_op_ratelimit_recurrence.md\`
- Free-call verification: \`memory/feedback_op_rate_limit_care.md\`
- Root-cause for the underlying drain (NOT addressed by this PR): #124, dynamic Proxmox inventory bypass