### PR TITLE
feat(unattended_upgrades): expose apt_upgrades_pending_total gauge

### DIFF
--- a/roles/unattended_upgrades/templates/update-metrics.sh.j2
+++ b/roles/unattended_upgrades/templates/update-metrics.sh.j2
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Managed by Ansible — do not edit manually
+# Managed by Ansible. Do not edit manually.
 # Writes Prometheus metrics for unattended-upgrades status.
 # Called via apt post-invoke hook after every apt operation.
 set -euo pipefail
@@ -17,8 +17,16 @@ else
     reboot_required=0
 fi
 
-# Pending security updates
+# Pending security updates (Ubuntu/Debian -security pocket only).
+# Note: third-party repos (Kubernetes, HashiCorp, Wazuh, etc.) do not have
+# a -security suffix and are intentionally NOT counted here.
 pending=$(apt list --upgradable 2>/dev/null | grep -c "\-security" || true)
+
+# Total pending upgrades, including third-party repos. Mirrors the count
+# that the MOTD apt-check shows on SSH login. tail -n +2 strips the
+# "Listing..." header. || true preserves set -e under pipefail when apt
+# is locked or empty.
+total_pending=$(apt list --upgradable 2>/dev/null | tail -n +2 | wc -l || true)
 
 # Last unattended-upgrades result (parse most recent run from log)
 last_success=1
@@ -48,6 +56,9 @@ unattended_upgrades_success ${last_success}
 # HELP unattended_upgrades_pending_security Number of pending security updates.
 # TYPE unattended_upgrades_pending_security gauge
 unattended_upgrades_pending_security ${pending}
+# HELP apt_upgrades_pending_total Total pending apt upgrades across all sources, including third-party repos.
+# TYPE apt_upgrades_pending_total gauge
+apt_upgrades_pending_total ${total_pending}
 # HELP unattended_upgrades_last_run_timestamp_seconds Unix timestamp of last unattended-upgrades run.
 # TYPE unattended_upgrades_last_run_timestamp_seconds gauge
 unattended_upgrades_last_run_timestamp_seconds ${last_timestamp}


### PR DESCRIPTION
## Summary

Add a new Prometheus gauge `apt_upgrades_pending_total` that counts all upgradable apt packages, derived from `apt list --upgradable | tail -n +2 | wc -l`. The existing `unattended_upgrades_pending_security` gauge is preserved unchanged.

## Why

The existing security gauge filters via `grep -c "\\-security"`, which only matches the Ubuntu/Debian `-security` pocket suffix. Third-party repos (Kubernetes, HashiCorp, Vector, Wazuh) do not carry that suffix, so the security gauge stays at 0 even when multiple non-security upgrades are pending. The MOTD apt-check on SSH login counts ALL upgradable packages, which causes user-visible divergence ("I see 4 updates on SSH but the dashboard says 0").

This PR adds the total count alongside the security count so dashboards can show both panels and the MOTD/dashboard discrepancy goes away.

The existing security gauge is intentionally left as-is; it is correct under its name. The new gauge is additive.

## Test plan

- [x] Bash syntax check on rendered template (`bash -n` after substituting `{{ }}` placeholders) passes
- [x] Manual run on command-center1 produces `apt_upgrades_pending_total 4` (matches `apt list --upgradable | tail -n +2 | wc -l`); existing `unattended_upgrades_pending_security 0` unchanged
- [x] Verified via `curl -s http://localhost:9100/metrics | grep apt_upgrades_pending_total` that node_exporter exposes the new metric
- [ ] Re-apply role to a fleet sample and confirm the gauge appears on every host
- [ ] Add a Grafana panel surfacing the new gauge (separate PR in k8s-argocd)

## Style

Strips one em dash from the file's "Managed by Ansible" header comment to comply with the repo's no-em-dash convention.