### PR TITLE
Add nut_client role for coordinated UPS shutdown

### DIFF
--- a/playbooks/ups-shutdown.yml
+++ b/playbooks/ups-shutdown.yml
@@ -1,0 +1,31 @@
+---
+# Coordinated UPS shutdown for the Proxmox hosts (NUT secondaries).
+# The TrueNAS NAS is the NUT primary (UPS USB attached) and is configured
+# separately in the TrueNAS UPS service. See roles/nut_client.
+#
+# Secret convention matches the rest of the repo: the upsmon password comes
+# from the NUT_MONITOR_PASSWORD env var. For a direct run, export it first:
+#   NUT_MONITOR_PASSWORD="$(op read 'op://Infrastructure/NUT upsmon/password')" \
+#     ansible-playbook playbooks/ups-shutdown.yml
+- name: Configure NUT UPS-triggered shutdown on Proxmox hosts
+  hosts: proxmox
+  become: true
+  pre_tasks:
+    - name: Assert NUT_MONITOR_PASSWORD env is populated
+      delegate_to: localhost
+      become: false
+      run_once: true
+      ansible.builtin.assert:
+        that:
+          - lookup('env', 'NUT_MONITOR_PASSWORD') | length > 0
+        fail_msg: >-
+          NUT_MONITOR_PASSWORD is empty or unset. Export it first, e.g.
+          NUT_MONITOR_PASSWORD="$(op read 'op://Infrastructure/NUT upsmon/password')".
+        quiet: true
+
+    - name: Resolve NUT monitor password from env
+      ansible.builtin.set_fact:
+        nut_monitor_password: "{{ lookup('env', 'NUT_MONITOR_PASSWORD') }}"
+      no_log: true
+  roles:
+    - nut_client

--- a/roles/nut_client/defaults/main.yml
+++ b/roles/nut_client/defaults/main.yml
@@ -1,0 +1,31 @@
+---
+# NUT (Network UPS Tools) secondary client for coordinated UPS shutdown.
+#
+# Topology: the CyberPower CP1500AVRLCD3 USB cable plugs into the TrueNAS NAS,
+# which runs as the NUT *primary* (upsd + upsmon, dies LAST). These Proxmox
+# hosts run as *secondaries*: after nut_onbatt_shutdown_delay seconds on
+# battery they gracefully power off, which stops their guests first. Because
+# the primary (NAS) uses a longer on-battery timer, it powers off last, after
+# its only storage consumers are already down. This is the shutdown-side
+# counterpart to roles/pve/freenas_iscsi's boot-side pve-guests wait-for-NAS.
+nut_primary_host: 192.168.1.15
+nut_ups_name: ups
+nut_monitor_user: pvemon
+# nut_monitor_password is NOT defaulted. playbooks/ups-shutdown.yml sets it as
+# a fact from the NUT_MONITOR_PASSWORD env var, matching this repo's secret
+# convention (env vars populated by op-secret-cache; see scripts/lib).
+
+# Seconds on battery before THIS host begins its graceful shutdown.
+nut_onbatt_shutdown_delay: 60
+
+nut_poll_freq: 5
+nut_poll_freq_alert: 5
+nut_hostsync: 15
+nut_deadtime: 15
+nut_shutdown_cmd: /sbin/poweroff
+
+# Proxmox HA: with HA active, a node powering off can make HA relocate guests
+# onto the surviving node, which is pointless and risky during a whole-rack
+# power-down. "freeze" tells HA the node is going down on purpose.
+nut_set_ha_shutdown_policy: true
+nut_ha_shutdown_policy: freeze

--- a/roles/nut_client/handlers/main.yml
+++ b/roles/nut_client/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Restart nut-monitor
+  ansible.builtin.systemd:
+    name: nut-monitor
+    state: restarted
+    enabled: true
+    daemon_reload: true

--- a/roles/nut_client/tasks/main.yml
+++ b/roles/nut_client/tasks/main.yml
@@ -1,0 +1,80 @@
+---
+- name: Fail early if the NUT monitor password was not provided
+  ansible.builtin.assert:
+    that:
+      - nut_monitor_password is defined
+      - nut_monitor_password | length > 0
+    fail_msg: >-
+      nut_monitor_password is empty. Run via playbooks/ups-shutdown.yml, which
+      sets it from the NUT_MONITOR_PASSWORD env var (export it first, e.g.
+      NUT_MONITOR_PASSWORD="$(op read 'op://Infrastructure/NUT upsmon/password')").
+    quiet: true
+
+- name: Install NUT client
+  ansible.builtin.apt:
+    name: nut-client
+    state: present
+    update_cache: true
+
+- name: Set NUT to netclient mode
+  ansible.builtin.copy:
+    dest: /etc/nut/nut.conf
+    content: |
+      # Managed by Ansible (nut_client role)
+      MODE=netclient
+    owner: root
+    group: nut
+    mode: '0640'
+  notify: Restart nut-monitor
+
+- name: Deploy upsmon.conf
+  ansible.builtin.template:
+    src: upsmon.conf.j2
+    dest: /etc/nut/upsmon.conf
+    owner: root
+    group: nut
+    mode: '0640'
+  no_log: true  # contains the monitor password
+  notify: Restart nut-monitor
+
+- name: Deploy upssched.conf
+  ansible.builtin.template:
+    src: upssched.conf.j2
+    dest: /etc/nut/upssched.conf
+    owner: root
+    group: nut
+    mode: '0640'
+  notify: Restart nut-monitor
+
+- name: Deploy upssched command script
+  ansible.builtin.template:
+    src: upssched-cmd.j2
+    dest: /etc/nut/upssched-cmd
+    owner: root
+    group: nut
+    mode: '0750'
+  notify: Restart nut-monitor
+
+- name: Enable and start nut-monitor
+  ansible.builtin.systemd:
+    name: nut-monitor
+    enabled: true
+    state: started
+
+# --- Proxmox HA: prevent guest relocation during a coordinated power-down ---
+- name: Read current Proxmox cluster options
+  ansible.builtin.command: pvesh get /cluster/options --output-format json
+  register: pve_cluster_options
+  run_once: true
+  changed_when: false
+  check_mode: false
+  when: nut_set_ha_shutdown_policy | bool
+
+- name: Set HA shutdown policy to freeze
+  ansible.builtin.command: >-
+    pvesh set /cluster/options --ha shutdown_policy={{ nut_ha_shutdown_policy }}
+  run_once: true
+  when:
+    - nut_set_ha_shutdown_policy | bool
+    - ((pve_cluster_options.stdout | default('{}') | from_json).ha | default({})).shutdown_policy | default('conditional') != nut_ha_shutdown_policy
+  changed_when: true

--- a/roles/nut_client/templates/upsmon.conf.j2
+++ b/roles/nut_client/templates/upsmon.conf.j2
@@ -1,0 +1,25 @@
+# {{ ansible_managed }}
+# NUT secondary monitoring the UPS served by the TrueNAS primary.
+RUN_AS_USER root
+
+MONITOR {{ nut_ups_name }}@{{ nut_primary_host }} 1 {{ nut_monitor_user }} {{ nut_monitor_password }} secondary
+
+MINSUPPLIES 1
+SHUTDOWNCMD "{{ nut_shutdown_cmd }}"
+POLLFREQ {{ nut_poll_freq }}
+POLLFREQALERT {{ nut_poll_freq_alert }}
+HOSTSYNC {{ nut_hostsync }}
+DEADTIME {{ nut_deadtime }}
+
+# Hand events to upssched so we can run an on-battery delay timer.
+NOTIFYCMD /sbin/upssched
+
+NOTIFYFLAG ONLINE   SYSLOG+EXEC
+NOTIFYFLAG ONBATT   SYSLOG+EXEC
+NOTIFYFLAG LOWBATT  SYSLOG+EXEC
+NOTIFYFLAG FSD      SYSLOG+EXEC
+NOTIFYFLAG COMMOK   SYSLOG
+NOTIFYFLAG COMMBAD  SYSLOG
+NOTIFYFLAG SHUTDOWN SYSLOG
+NOTIFYFLAG REPLBATT SYSLOG
+NOTIFYFLAG NOCOMM   SYSLOG

--- a/roles/nut_client/templates/upssched-cmd.j2
+++ b/roles/nut_client/templates/upssched-cmd.j2
@@ -1,0 +1,19 @@
+#!/bin/sh
+# {{ ansible_managed }}
+# Invoked by upssched when a timer fires or an immediate event occurs.
+# {{ nut_shutdown_cmd }} triggers a graceful systemd poweroff, which stops the
+# pve-guests service (gracefully shutting each VM) before the host powers off.
+
+case "$1" in
+  onbatt-shutdown)
+    logger -t upssched-cmd "UPS on battery for {{ nut_onbatt_shutdown_delay }}s - initiating graceful shutdown (guests first)"
+    {{ nut_shutdown_cmd }}
+    ;;
+  forced-shutdown)
+    logger -t upssched-cmd "UPS low battery / forced shutdown - powering off now"
+    {{ nut_shutdown_cmd }}
+    ;;
+  *)
+    logger -t upssched-cmd "Unrecognized upssched command: $1"
+    ;;
+esac

--- a/roles/nut_client/templates/upssched.conf.j2
+++ b/roles/nut_client/templates/upssched.conf.j2
@@ -1,0 +1,13 @@
+# {{ ansible_managed }}
+CMDSCRIPT /etc/nut/upssched-cmd
+PIPEFN /run/nut/upssched.pipe
+LOCKFN /run/nut/upssched.lock
+
+# On battery: start a timer. If utility power returns before it expires, the
+# ONLINE event cancels it and nothing happens (rides through brief flickers).
+AT ONBATT * START-TIMER onbatt-shutdown {{ nut_onbatt_shutdown_delay }}
+AT ONLINE * CANCEL-TIMER onbatt-shutdown
+
+# Battery actually got low, or the primary forced a shutdown: go now.
+AT LOWBATT * EXECUTE forced-shutdown
+AT FSD     * EXECUTE forced-shutdown


### PR DESCRIPTION
## What

Adds a `nut_client` role + `playbooks/ups-shutdown.yml` so a power outage triggers a **coordinated, ordered shutdown** instead of the manual scramble we did on 2026-05-20.

The dependency order matters: Proxmox guests have disks on TrueNAS via iSCSI/NFS, so guests must stop, then the PVE hosts, and the **NAS must power off last** or running guests lose their storage mid-write.

## How it works

- UPS (CyberPower CP1500AVRLCD3) USB plugs into TrueNAS, which is the NUT **primary** (configured in the TrueNAS UPS service, 300s on-battery timer).
- pve1/pve2 run as NUT **secondaries** (this role). After `nut_onbatt_shutdown_delay` (60s) on battery, `upssched` fires a graceful `poweroff`, which stops the guests first via `pve-guests`.
- Because the NAS primary uses a longer timer, it dies last, after its only storage consumers are already down. The QDevice lives on the NAS, so quorum survives until the PVE nodes are gone.
- Sets Proxmox HA `shutdown_policy=freeze` so guests are not relocated during a whole-rack power-down.

This is the **shutdown-side counterpart** to `roles/pve/freenas_iscsi`'s existing boot-side `pve-guests` wait-for-TrueNAS drop-in, so boot and shutdown ordering are now both handled.

## Secret handling

The `upsmon` password comes from the `NUT_MONITOR_PASSWORD` env var (same `lookup('env', ...)` convention as wazuh.yml/postgresql.yml, populated from 1Password via op-secret-cache). Nothing secret is committed.

## Not included (deliberately)

The May 6 timer disable does **not** need a cadence change: `op-secret-cache.sh` (12h TTL) already decouples `op` call volume from timer frequency, so the original token-burn reason is gone. The fix there is purely operational (re-enable the timers at 30min/1h and watch the op rate), tracked separately.

## Test plan

- [x] YAML + Jinja2 parse clean
- [x] 1Password item `op://Infrastructure/NUT upsmon/password` retrievable from command-center1
- [x] TrueNAS primary online: `upsc ups@localhost ups.status` = `OL`, battery 100%, model CP1500AVRLCD3
- [x] NAS `upsd` reachable on `:3493` from pve1
- [ ] `ansible-playbook playbooks/ups-shutdown.yml --syntax-check` on command-center1
- [ ] Canary apply to pve1, verify `upsc ups@192.168.1.15 ups.status` = `OL` and `nut-monitor` reports comms established
- [ ] Apply pve2
- [ ] Live battery test in a maintenance window: pull mains, confirm guests stop, hosts off ~1-3 min, NAS off ~5 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)
