### PR TITLE
Harden nut_client HA shutdown_policy idempotency check

### DIFF
--- a/roles/nut_client/tasks/main.yml
+++ b/roles/nut_client/tasks/main.yml
@@ -62,11 +62,17 @@
     state: started
 
 # --- Proxmox HA: prevent guest relocation during a coordinated power-down ---
-- name: Read current Proxmox cluster options
-  ansible.builtin.command: pvesh get /cluster/options --output-format json
-  register: pve_cluster_options
+- name: Read current HA shutdown policy from datacenter.cfg
+  # Read the policy from the cluster config file rather than parsing
+  # `pvesh get /cluster/options --output-format json`, whose `ha` field
+  # shape varies by Proxmox version (a JSON object on PVE 8, but can be a
+  # `key=value` format-string elsewhere). datacenter.cfg always stores it
+  # as `ha: shutdown_policy=<value>`, so this stays idempotent regardless.
+  ansible.builtin.command: grep -oP '^ha:.*shutdown_policy=\K\w+' /etc/pve/datacenter.cfg
+  register: pve_ha_policy
   run_once: true
   changed_when: false
+  failed_when: false  # grep exits 1 when ha line/policy is absent; empty stdout is the signal to set it
   check_mode: false
   when: nut_set_ha_shutdown_policy | bool
 
@@ -76,5 +82,5 @@
   run_once: true
   when:
     - nut_set_ha_shutdown_policy | bool
-    - ((pve_cluster_options.stdout | default('{}') | from_json).ha | default({})).shutdown_policy | default('conditional') != nut_ha_shutdown_policy
+    - (pve_ha_policy.stdout | default('') | trim) != nut_ha_shutdown_policy
   changed_when: true


### PR DESCRIPTION
## What

Follow-up to #131 addressing the Codex review on the HA `shutdown_policy` idempotency guard.

The original check parsed `pvesh get /cluster/options --output-format json` and read `.ha.shutdown_policy`. On PVE 8 `ha` is a JSON object (`{"shutdown_policy": "freeze"}`), so it works and is idempotent (verified: the task skips on an already-configured node). But Codex correctly noted the `ha` field shape is version-fragile: where Proxmox exposes it as a `key=value` format-string, `.shutdown_policy` would resolve undefined, fall back to `conditional`, and re-run `pvesh set` on every play.

## Change

Read the current policy from `datacenter.cfg` (`ha: shutdown_policy=<value>`), which is stable across versions, instead of parsing the variable-shaped `pvesh` JSON.

## Test

Applied to pve1 (already at `freeze`):

```
TASK [nut_client : Read current HA shutdown policy from datacenter.cfg] ********
ok: [pve]
TASK [nut_client : Set HA shutdown policy to freeze] ***************************
skipping: [pve]
PLAY RECAP: pve : ok=11 changed=0 failed=0 skipped=1
```

`changed=0` on a re-run confirms idempotency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
