### PR TITLE
Harden GPU passthrough: K620-aware watchdog + persist pcie_aspm=off in grub

### DIFF
--- a/roles/jellyfin/defaults/main.yml
+++ b/roles/jellyfin/defaults/main.yml
@@ -9,6 +9,13 @@ jellyfin_http_port: 8096
 jellyfin_ffmpeg_path: /usr/lib/jellyfin-ffmpeg/ffmpeg
 nvidia_driver_version: "570"
 
+# Watchdog only performs destructive recovery (kill ffmpeg, stop jellyfin,
+# rmmod/modprobe nvidia) when the detected GPU name contains this substring.
+# On any other GPU (e.g. K620 failover path) the watchdog enters passive mode:
+# probes and emits metrics but never restarts services or reloads modules.
+# Set to empty string to disable the gate (always run in active mode).
+gpu_watchdog_expected_gpu_substring: "GeForce RTX 2080 Ti"
+
 # Monitoring
 node_exporter_textfile_dir: /var/lib/node_exporter/textfiles
 jellyfin_monitoring_api_key: ""

--- a/roles/jellyfin/templates/gpu-watchdog.sh.j2
+++ b/roles/jellyfin/templates/gpu-watchdog.sh.j2
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# GPU watchdog — detects GPU failure and auto-recovers
-# Managed by Ansible — do not edit manually
+# GPU watchdog: detects GPU failure and auto-recovers.
+# Managed by Ansible, do not edit manually.
 set -euo pipefail
 
 INTERVAL=30
@@ -8,8 +8,16 @@ SMI_TIMEOUT=10
 LOG_TAG="gpu-watchdog"
 FAIL_COUNT=0
 MAX_SOFT_RETRIES=2
+EXPECTED_GPU={{ gpu_watchdog_expected_gpu_substring | quote }}
 PROM_FILE="{{ node_exporter_textfile_dir }}/gpu_watchdog.prom"
 TMPFILE="${PROM_FILE}.tmp"
+
+# Passive mode: probe and emit metrics but never perform destructive recovery
+# (kill ffmpeg, stop jellyfin, rmmod nvidia). Activated when the detected GPU
+# does not match EXPECTED_GPU, e.g. when HA fails the VM over to a fallback
+# node with a different card. Prevents 2080 Ti-tuned recovery logic from
+# crash-looping on a K620 and SIGTERMing every transcode (incident 2026-05-27).
+PASSIVE=0
 
 # Load persisted counters from existing prom file
 failures_total=0
@@ -42,6 +50,28 @@ METRICS
 # Write initial metrics
 write_metrics
 
+# Decide active vs passive mode based on the GPU currently present.
+# Retry a few times because the nvidia driver can take a moment after VM boot.
+for attempt in 1 2 3 4 5; do
+    detected_gpu=$(timeout "$SMI_TIMEOUT" nvidia-smi --query-gpu=name --format=csv,noheader 2>/dev/null | head -1 | tr -d '\r')
+    if [[ -n "$detected_gpu" ]]; then
+        break
+    fi
+    sleep 5
+done
+
+if [[ -z "$EXPECTED_GPU" ]]; then
+    log "EXPECTED_GPU not configured, running in active mode regardless of detected card"
+elif [[ -z "$detected_gpu" ]]; then
+    log "Initial GPU probe returned no device after retries; entering PASSIVE mode (metrics only)"
+    PASSIVE=1
+elif [[ "$detected_gpu" != *"$EXPECTED_GPU"* ]]; then
+    log "Detected GPU '$detected_gpu' does not match expected '$EXPECTED_GPU'; entering PASSIVE mode (metrics only)"
+    PASSIVE=1
+else
+    log "Detected expected GPU: $detected_gpu"
+fi
+
 while true; do
     if timeout "$SMI_TIMEOUT" nvidia-smi --query-gpu=name --format=csv,noheader &>/dev/null; then
         FAIL_COUNT=0
@@ -51,8 +81,14 @@ while true; do
 
     failures_total=$((failures_total + 1))
     FAIL_COUNT=$((FAIL_COUNT + 1))
-    log "GPU failure detected (attempt ${FAIL_COUNT}/${MAX_SOFT_RETRIES}) — total failures: ${failures_total}"
+    log "GPU failure detected (attempt ${FAIL_COUNT}/${MAX_SOFT_RETRIES}), total failures: ${failures_total}"
     write_metrics
+
+    if [[ "$PASSIVE" -eq 1 ]]; then
+        # Skip destructive recovery on fallback GPU; just probe and wait.
+        sleep "$INTERVAL"
+        continue
+    fi
 
     # Stop Jellyfin to release GPU references
     log "Stopping Jellyfin..."

--- a/roles/pve/gpu_passthrough/defaults/main.yml
+++ b/roles/pve/gpu_passthrough/defaults/main.yml
@@ -19,4 +19,17 @@ pve_gpu_blacklist:
 
 # IOMMU settings
 pve_iommu_type: "amd"  # amd or intel
-pve_grub_cmdline: "quiet {{ pve_iommu_type }}_iommu=on iommu=pt"
+
+# Base kernel cmdline applied on every pve node (passthrough or not).
+pve_grub_cmdline_base: "quiet {{ pve_iommu_type }}_iommu=on iommu=pt"
+
+# Extra cmdline args applied only when pve_gpu_passthrough is true.
+# vfio-pci.ids: kept on cmdline (in addition to /etc/modprobe.d/vfio.conf)
+# so vfio binds the device before any host driver can claim it during boot.
+# pcie_aspm=off: required for consumer NVIDIA cards under vfio passthrough
+# to avoid D3cold wake failures that drop the GPU off the PCI bus until a
+# host cold reboot (incident 2026-05-27 on pve2).
+pve_grub_cmdline_passthrough_extra: "vfio-pci.ids={{ pve_vfio_pci_ids }} pcie_aspm=off"
+
+# Final cmdline rendered into /etc/default/grub.
+pve_grub_cmdline: "{{ pve_grub_cmdline_base }}{% if pve_gpu_passthrough %} {{ pve_grub_cmdline_passthrough_extra }}{% endif %}"


### PR DESCRIPTION
## Summary

Two structural fixes that come out of the **2026-05-27 jellyfin GPU incident** (full RCA in memory: `project_2026-05-27_jellyfin_gpu_recovery.md`).

### 1. K620-aware gpu-watchdog (`roles/jellyfin/`)

The watchdog kept tightly coupling its destructive recovery (kill ffmpeg, stop jellyfin, rmmod/modprobe nvidia) to whichever GPU happened to be present. When HA failed VM 115 from pve2 (RTX 2080 Ti) over to pve (Quadro K620), the watchdog crash-looped: 99 cumulative failures logged, every transcode SIGTERMed within 60 seconds.

New variable `gpu_watchdog_expected_gpu_substring` (default `"GeForce RTX 2080 Ti"`). At startup the script probes `nvidia-smi`, and if the detected card does not contain that substring it enters **PASSIVE** mode: still probes and emits Prometheus metrics, but never restarts services or reloads modules. The K620 fallback path can now serve h264 transcodes without interference.

### 2. Persist `vfio-pci.ids` and add `pcie_aspm=off` to pve grub cmdline (`roles/pve/gpu_passthrough/`)

Two issues fixed together because they share `pve_grub_cmdline`:

- `vfio-pci.ids=...` was live in pve2's running cmdline (hand-added long ago) but **not** in the Ansible default. The next run would have stripped it. Now templated when `pve_gpu_passthrough` is true.
- `pcie_aspm=off` is the standard mitigation for the consumer-Turing D3cold wake failure that caused the incident (`vfio-pci 0000:0a:00.0: Unable to change power state from D3cold to D0, device inaccessible`). Now applied in the same passthrough-extra block.

The variable was split into `_base` and `_passthrough_extra` so non-passthrough nodes are unaffected.

## Test plan

- [x] `ansible-playbook --syntax-check` on both `playbooks/proxmox.yml` and `playbooks/jellyfin.yml`
- [x] `--check --diff` against `pve2` and `jellyfin`, reviewed both diffs
- [x] Real apply against `jellyfin`: watchdog deployed, service restarted, journal confirms `Detected expected GPU: NVIDIA GeForce RTX 2080 Ti` (ACTIVE mode, not PASSIVE)
- [x] Real apply against `pve2`: `changed=0` (idempotent against current state)
- [x] Jellyfin HTTP 200 direct + proxy after restart
- [ ] K620 path live test deferred (would require forcing a failover and another pve2 cold reboot, both disruptive). Logic verified by code review and the active-path test.